### PR TITLE
Feature/add is postback check

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -55,6 +55,8 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     protected $driverEvent;
 
     protected $facebookProfileEndpoint = 'https://graph.facebook.com/v2.6/';
+    /** @var bool If the incoming request is a FB postback */
+    protected $isPostback = false;
 
     const DRIVER_NAME = 'Facebook';
 
@@ -215,6 +217,8 @@ class FacebookDriver extends HttpDriver implements VerifiesService
                 return new IncomingMessage($msg['message']['text'], $msg['sender']['id'], $msg['recipient']['id'],
                     $msg);
             } elseif (isset($msg['postback']['payload'])) {
+                $this->isPostback = true;
+
                 return new IncomingMessage($msg['postback']['payload'], $msg['sender']['id'], $msg['recipient']['id'],
                     $msg);
             }
@@ -236,6 +240,16 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     {
         // Facebook bot replies don't get returned
         return false;
+    }
+
+    /**
+     * Tells if the current request is a callback.
+     *
+     * @return bool
+     */
+    public function isPostback()
+    {
+        return $this->isPostback;
     }
 
     /**

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -55,6 +55,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     protected $driverEvent;
 
     protected $facebookProfileEndpoint = 'https://graph.facebook.com/v2.6/';
+
     /** @var bool If the incoming request is a FB postback */
     protected $isPostback = false;
 

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -126,6 +126,15 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_sets_the_postback_check_value()
+    {
+        $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"postback":{"payload":"MY_PAYLOAD"}}]}]}';
+        $driver = $this->getDriver($request);
+        $driver->getMessages();
+        $this->assertTrue($driver->isPostback());
+    }
+
+    /** @test */
     public function it_shows_that_postback_is_no_event_anymore()
     {
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"postback":{"payload":"MY_PAYLOAD"}}]}]}';


### PR DESCRIPTION
This PR adds an `isPostback` method to the Facebookdriver so that we can check for a request if it comes from a postback.