### PR TITLE
Add example data for the persistent menu and get started payload

### DIFF
--- a/src/Commands/AddPersistentMenu.php
+++ b/src/Commands/AddPersistentMenu.php
@@ -44,7 +44,7 @@ class AddPersistentMenu extends Command
      */
     public function handle()
     {
-        $payload = config('botman.facebook.persistent_menu');
+        $payload = ['persistent_menu' => config('botman.facebook.persistent_menu')];
 
         if (! $payload) {
             $this->error('You need to add a Facebook menu payload data to your BotMan Facebook config in facebook.php.');

--- a/stubs/facebook.php
+++ b/stubs/facebook.php
@@ -33,4 +33,48 @@ return [
     |
     */
     'verification' => env('FACEBOOK_VERIFICATION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Facebook Start Button Payload
+    |--------------------------------------------------------------------------
+    |
+    | The payload which is sent when the Get Started Button is clicked.
+    |
+    */
+    'start_button_payload' => 'GET_STARTED',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Facebook Persistent Menu
+    |--------------------------------------------------------------------------
+    |
+    | Example items for your persistent Facebook menu.
+    |
+    */
+    'persistent_menu' => [
+        [
+            'locale' => 'default',
+            'composer_input_disabled' => 'true',
+            'call_to_actions' => [
+                [
+                    'title' => 'My Account',
+                    'type' => 'nested',
+                    'call_to_actions' => [
+                        [
+                            'title' => 'Pay Bill',
+                            'type' => 'postback',
+                            'payload' => 'PAYBILL_PAYLOAD',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'web_url',
+                    'title' => 'Latest News',
+                    'url' => 'http://botman.io',
+                    'webview_height_ratio' => 'full',
+                ],
+            ],
+        ],
+    ],
 ];


### PR DESCRIPTION
This PR adds example data to the Facebook config so that people get a better feeling for how to customise ist.