### PR TITLE
Feature/add media template

### DIFF
--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -12,7 +12,7 @@ class MediaAttachmentElement implements JsonSerializable
     /** @var string */
     protected $attachment_id;
 
-    /** @var  array */
+    /** @var array */
     protected $buttons;
 
     /**

--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BotMan\Drivers\Facebook\Extensions;
+
+use JsonSerializable;
+
+class MediaAttachmentElement implements JsonSerializable
+{
+    /** @var string */
+    protected $media_type;
+
+    /** @var string */
+    protected $attachment_id;
+
+    /** @var  array */
+    protected $buttons;
+
+    /**
+     * @param $mediaType
+     * @return static
+     */
+    public static function create($mediaType)
+    {
+        return new static($mediaType);
+    }
+
+    /**
+     * @param $mediaType
+     */
+    public function __construct($mediaType)
+    {
+        $this->media_type = $mediaType;
+    }
+
+    /**
+     * @param $attachmentId
+     * @return $this
+     */
+    public function attachmentId($attachmentId)
+    {
+        $this->attachment_id = $attachmentId;
+
+        return $this;
+    }
+
+    /**
+     * @param ElementButton $button
+     * @return $this
+     */
+    public function addButton(ElementButton $button)
+    {
+        $this->buttons[] = $button->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param array $buttons
+     * @return $this
+     */
+    public function addButtons(array $buttons)
+    {
+        foreach ($buttons as $button) {
+            if ($button instanceof ElementButton) {
+                $this->buttons[] = $button->toArray();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'media_type' => $this->media_type,
+            'attachment_id' => $this->attachment_id,
+            'buttons' => $this->buttons,
+        ];
+
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -79,7 +79,6 @@ class MediaAttachmentElement implements JsonSerializable
             'attachment_id' => $this->attachment_id,
             'buttons' => $this->buttons,
         ];
-
     }
 
     /**

--- a/src/Extensions/MediaTemplate.php
+++ b/src/Extensions/MediaTemplate.php
@@ -7,7 +7,7 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class MediaTemplate implements JsonSerializable, WebAccess
 {
-    /** @var  string */
+    /** @var string */
     protected $mediaType;
 
     /** @var array */

--- a/src/Extensions/MediaTemplate.php
+++ b/src/Extensions/MediaTemplate.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace BotMan\Drivers\Facebook\Extensions;
+
+use JsonSerializable;
+use BotMan\BotMan\Interfaces\WebAccess;
+
+class MediaTemplate implements JsonSerializable, WebAccess
+{
+    /** @var  string */
+    protected $mediaType;
+
+    /** @var array */
+    protected $elements = [];
+
+    /**
+     * @return static
+     */
+    public static function create()
+    {
+        return new static();
+    }
+
+    /**
+     * @param $element
+     * @return $this
+     */
+    public function element($element)
+    {
+        $this->elements = [$element->toArray()];
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'attachment' => [
+                'type' => 'template',
+                'payload' => [
+                    'template_type' => 'media',
+                    'elements' => $this->elements,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Get the instance as a web accessible array.
+     * This will be used within the WebDriver.
+     *
+     * @return array
+     */
+    public function toWebDriver()
+    {
+        return [
+            'type' => $this->mediaType,
+            'elements' => $this->elements,
+        ];
+    }
+}

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace BotMan\Drivers\Facebook\Extensions;
+
+use JsonSerializable;
+
+class MediaUrlElement implements JsonSerializable
+{
+    /** @var string */
+    protected $media_type;
+
+    /** @var string */
+    protected $url;
+
+    /** @var  array */
+    protected $buttons;
+
+    /**
+     * @param $mediaType
+     * @return static
+     */
+    public static function create($mediaType)
+    {
+        return new static($mediaType);
+    }
+
+    /**
+     * @param $mediaType
+     */
+    public function __construct($mediaType)
+    {
+        $this->media_type = $mediaType;
+    }
+
+    /**
+     * @param $url
+     * @return $this
+     */
+    public function url($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * @param ElementButton $button
+     * @return $this
+     */
+    public function addButton(ElementButton $button)
+    {
+        $this->buttons[] = $button->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param array $buttons
+     * @return $this
+     */
+    public function addButtons(array $buttons)
+    {
+        foreach ($buttons as $button) {
+            if ($button instanceof ElementButton) {
+                $this->buttons[] = $button->toArray();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        return [
+            'media_type' => $this->media_type,
+            'url' => $this->url,
+            'buttons' => $this->buttons,
+        ];
+
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -12,7 +12,7 @@ class MediaUrlElement implements JsonSerializable
     /** @var string */
     protected $url;
 
-    /** @var  array */
+    /** @var array */
     protected $buttons;
 
     /**

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -79,7 +79,6 @@ class MediaUrlElement implements JsonSerializable
             'url' => $this->url,
             'buttons' => $this->buttons,
         ];
-
     }
 
     /**

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -2,7 +2,6 @@
 
 namespace BotMan\Drivers\Facebook;
 
-use BotMan\Drivers\Facebook\Extensions\MediaTemplate;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Messages\Incoming\Answer;
@@ -23,6 +22,7 @@ use BotMan\Drivers\Facebook\Events\MessagingOptins;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 use BotMan\Drivers\Facebook\Extensions\ListTemplate;
+use BotMan\Drivers\Facebook\Extensions\MediaTemplate;
 use BotMan\Drivers\Facebook\Events\MessagingReferrals;
 use BotMan\Drivers\Facebook\Extensions\ButtonTemplate;
 use BotMan\Drivers\Facebook\Events\MessagingDeliveries;

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -361,7 +361,6 @@ class FacebookDriver extends HttpDriver implements VerifiesService
      */
     public function sendPayload($payload)
     {
-        \Log::info('FB payload:', $payload);
         $response = $this->http->post($this->facebookProfileEndpoint.'me/messages', [], $payload);
         $this->throwExceptionIfResponseNotOk($response);
 

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\Drivers\Facebook;
 
+use BotMan\Drivers\Facebook\Extensions\MediaTemplate;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Messages\Incoming\Answer;
@@ -48,6 +49,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         GenericTemplate::class,
         ListTemplate::class,
         ReceiptTemplate::class,
+        MediaTemplate::class,
     ];
 
     private $supportedAttachments = [
@@ -359,6 +361,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
      */
     public function sendPayload($payload)
     {
+        \Log::info('FB payload:', $payload);
         $response = $this->http->post($this->facebookProfileEndpoint.'me/messages', [], $payload);
         $this->throwExceptionIfResponseNotOk($response);
 

--- a/tests/Extensions/ElementButtonTest.php
+++ b/tests/Extensions/ElementButtonTest.php
@@ -102,7 +102,7 @@ class ElementButtonTest extends PHPUnit_Framework_TestCase
         $button = new ElementButton('click me');
         $button->disableShare();
 
-        $this->assertSame('hide', Arr::get($button->toArray(), 'webview_share_button'));
+        $this->assertSame('HIDE', Arr::get($button->toArray(), 'webview_share_button'));
     }
 
     /**

--- a/tests/Extensions/MediaAttachmentElementTest.php
+++ b/tests/Extensions/MediaAttachmentElementTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Extensions;
+
+use Illuminate\Support\Arr;
+use PHPUnit_Framework_TestCase;
+use BotMan\Drivers\Facebook\Extensions\ElementButton;
+use BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement;
+
+class MediaAttachmentElementTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $element = new MediaAttachmentElement('video');
+        $this->assertInstanceOf(MediaAttachmentElement::class, $element);
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_media_type()
+    {
+        $element = new MediaAttachmentElement('video');
+        $this->assertSame('video', Arr::get($element->toArray(), 'media_type'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_attachment_id()
+    {
+        $element = new MediaAttachmentElement('video');
+        $element->attachmentId('1234');
+        $this->assertSame('1234', Arr::get($element->toArray(), 'attachment_id'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_add_a_button()
+    {
+        $element = new MediaAttachmentElement('video');
+        $element->addButton(ElementButton::create('Button1'));
+        $this->assertSame('Button1', Arr::get($element->toArray(), 'buttons.0.title'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_add_a_buttons()
+    {
+        $element = new MediaAttachmentElement('video');
+        $element->addButtons([ElementButton::create('Button1'), ElementButton::create('Button2')]);
+        $this->assertSame('Button1', Arr::get($element->toArray(), 'buttons.0.title'));
+        $this->assertSame('Button2', Arr::get($element->toArray(), 'buttons.1.title'));
+    }
+}

--- a/tests/Extensions/MediaTemplateTest.php
+++ b/tests/Extensions/MediaTemplateTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Extensions;
+
+use Illuminate\Support\Arr;
+use PHPUnit_Framework_TestCase;
+use BotMan\Drivers\Facebook\Extensions\MediaTemplate;
+use BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement;
+
+class MediaTemplateTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $template = new MediaTemplate;
+        $this->assertInstanceOf(MediaTemplate::class, $template);
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_add_an_element()
+    {
+        $template = new MediaTemplate;
+        $template->element(MediaAttachmentElement::create('video'));
+
+        $this->assertSame('video', Arr::get($template->toArray(), 'attachment.payload.elements.0.media_type'));
+    }
+}

--- a/tests/Extensions/MediaUrlElementTest.php
+++ b/tests/Extensions/MediaUrlElementTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Extensions;
+
+use Illuminate\Support\Arr;
+use PHPUnit_Framework_TestCase;
+use BotMan\Drivers\Facebook\Extensions\ElementButton;
+use BotMan\Drivers\Facebook\Extensions\MediaUrlElement;
+
+class MediaUrlElementTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $element = new MediaUrlElement('video');
+        $this->assertInstanceOf(MediaUrlElement::class, $element);
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_media_type()
+    {
+        $element = new MediaUrlElement('video');
+        $this->assertSame('video', Arr::get($element->toArray(), 'media_type'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_url()
+    {
+        $element = new MediaUrlElement('video');
+        $element->url('https://botman.io');
+        $this->assertSame('https://botman.io', Arr::get($element->toArray(), 'url'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_add_a_button()
+    {
+        $element = new MediaUrlElement('video');
+        $element->addButton(ElementButton::create('Button1'));
+        $this->assertSame('Button1', Arr::get($element->toArray(), 'buttons.0.title'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_add_a_buttons()
+    {
+        $element = new MediaUrlElement('video');
+        $element->addButtons([ElementButton::create('Button1'), ElementButton::create('Button2')]);
+        $this->assertSame('Button1', Arr::get($element->toArray(), 'buttons.0.title'));
+        $this->assertSame('Button2', Arr::get($element->toArray(), 'buttons.1.title'));
+    }
+}


### PR DESCRIPTION
This PR adds the new Media template form Facebook.
It also adds the missing `setText` method in the `IncomingMessage` class.

I also added two types of elements (attachemnt and url) because I think this way it is to not the set the wrong values. (For attachment url would not be valid and for url attachment id would not be valid.