### PR TITLE
Update type drivers for type key exists checks

### DIFF
--- a/src/FacebookAudioDriver.php
+++ b/src/FacebookAudioDriver.php
@@ -21,7 +21,7 @@ class FacebookAudioDriver extends FacebookDriver
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
             if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return $attachment['type'] === 'audio';
+                    return (isset($attachment['type'])) && $attachment['type'] === 'audio';
                 })->isEmpty() === false;
             }
 

--- a/src/FacebookFileDriver.php
+++ b/src/FacebookFileDriver.php
@@ -21,7 +21,7 @@ class FacebookFileDriver extends FacebookDriver
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
             if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return $attachment['type'] === 'file';
+                    return (isset($attachment['type'])) && $attachment['type'] === 'file';
                 })->isEmpty() === false;
             }
 

--- a/src/FacebookImageDriver.php
+++ b/src/FacebookImageDriver.php
@@ -21,7 +21,7 @@ class FacebookImageDriver extends FacebookDriver
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
             if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return $attachment['type'] === 'image';
+                    return (isset($attachment['type'])) && $attachment['type'] === 'image';
                 })->isEmpty() === false;
             }
 

--- a/src/FacebookLocationDriver.php
+++ b/src/FacebookLocationDriver.php
@@ -21,7 +21,7 @@ class FacebookLocationDriver extends FacebookDriver
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
             if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return $attachment['type'] === 'location';
+                    return (isset($attachment['type'])) && $attachment['type'] === 'location';
                 })->isEmpty() === false;
             }
 


### PR DESCRIPTION
Due to lack of checks of the existence of the type key within the `matchesRequest()` method of each child driver type we get similar errors to the following - 

```
local.ERROR: Undefined index: type {"exception":"[object] (ErrorException(code: 0): Undefined index: type at /app/vendor/botman/driver-facebook/src/FacebookFileDriver.php:24)
```

```
local.ERROR: Undefined index: type {"exception":"[object] (ErrorException(code: 0): Undefined index: type at /app/vendor/botman/driver-facebook/src/FacebookAudioDriver.php:24)
```

```
local.ERROR: Undefined index: type {"exception":"[object] (ErrorException(code: 0): Undefined index: type at /app/vendor/botman/driver-facebook/src/FacebookImageDriver.php:24)
```

```
local.ERROR: Undefined index: type {"exception":"[object] (ErrorException(code: 0): Undefined index: type at /app/vendor/botman/driver-facebook/src/FacebookLocationDriver.php:24)
```

This PR resolves this issue by first checking for the existence of the type key.
