### PR TITLE
Feature/add quick reply types

### DIFF
--- a/src/Extensions/QuickReplyButton.php
+++ b/src/Extensions/QuickReplyButton.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace BotMan\Drivers\Facebook\Extensions;
+
+use BotMan\BotMan\Interfaces\QuestionActionInterface;
+
+class QuickReplyButton implements QuestionActionInterface
+{
+
+    /** @var string */
+    protected $contentType = self::TYPE_TEXT;
+
+    /** @var string */
+    protected $title;
+
+    /** @var string */
+    protected $payload;
+
+    /** @var string */
+    protected $imageUrl;
+
+    const TYPE_TEXT = 'text';
+
+    /**
+     * @param string $title
+     * @return static
+     */
+    public static function create($title = '')
+    {
+        return new static($title);
+    }
+
+    /**
+     * @param string $title
+     */
+    public function __construct($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Set the button type.
+     *
+     * @param string $type
+     * @return $this
+     */
+    public function type($type)
+    {
+        $this->contentType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param $payload
+     * @return $this
+     */
+    public function payload($payload)
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
+    /**
+     * Set the button URL.
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function imageUrl($url)
+    {
+        $this->imageUrl = $url;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray()
+    {
+        $buttonArray = [];
+
+        if ($this->contentType === 'text') {
+            $buttonArray = [
+                'content_type' => $this->contentType,
+                'title' => $this->title,
+                'payload' => $this->payload,
+                'image_url' => $this->imageUrl,
+            ];
+        } else {
+            $buttonArray['content_type'] = $this->contentType;
+        }
+
+        return $buttonArray;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Extensions/QuickReplyButton.php
+++ b/src/Extensions/QuickReplyButton.php
@@ -6,7 +6,6 @@ use BotMan\BotMan\Interfaces\QuestionActionInterface;
 
 class QuickReplyButton implements QuestionActionInterface
 {
-
     /** @var string */
     protected $contentType = self::TYPE_TEXT;
 

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -291,14 +291,20 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     {
         $questionData = $question->toArray();
 
-        $replies = Collection::make($question->getButtons())->map(function ($button) {
-            return array_merge([
-                'content_type' => 'text',
-                'title' => $button['text'],
-                'payload' => $button['value'],
-                'image_url' => $button['image_url'],
-            ], $button['additional']);
-        });
+        $replies = Collection::make($question->getButtons())
+            ->map(function ($button) {
+
+                if (isset($button['content_type']) && $button['content_type'] !== 'text') {
+                    return ['content_type' => $button['content_type']];
+                }
+
+                return array_merge([
+                    'content_type' => 'text',
+                    'title' => $button['text'] ?? $button['title'],
+                    'payload' => $button['value'] ?? $button['payload'],
+                    'image_url' => $button['image_url'] ?? $button['image_url'],
+                ], $button['additional'] ?? []);
+            });
 
         return [
             'text' => $questionData['text'],

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -293,7 +293,6 @@ class FacebookDriver extends HttpDriver implements VerifiesService
 
         $replies = Collection::make($question->getButtons())
             ->map(function ($button) {
-
                 if (isset($button['content_type']) && $button['content_type'] !== 'text') {
                     return ['content_type' => $button['content_type']];
                 }

--- a/tests/Extensions/QuickReplyButtonTest.php
+++ b/tests/Extensions/QuickReplyButtonTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Extensions;
+
+use Illuminate\Support\Arr;
+use PHPUnit_Framework_TestCase;
+use BotMan\Drivers\Facebook\Extensions\QuickReplyButton;
+
+class QuickReplyButtonTest extends PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_be_created()
+    {
+        $button = new QuickReplyButton('click me');
+        $this->assertInstanceOf(QuickReplyButton::class, $button);
+    }
+
+    /**
+     * @test
+     **/
+    public function standard_content_type_is_text()
+    {
+        $button = new QuickReplyButton('click me');
+
+        $this->assertSame('text', Arr::get($button->toArray(), 'content_type'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_type()
+    {
+        $button = new QuickReplyButton('click me');
+        $button->type('user_email');
+
+        $this->assertSame('user_email', Arr::get($button->toArray(), 'content_type'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_title()
+    {
+        $button = new QuickReplyButton('click me');
+
+        $this->assertSame('click me', Arr::get($button->toArray(), 'title'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_payload()
+    {
+        $button = new QuickReplyButton('click me');
+        $button->payload('clickme');
+
+        $this->assertSame('clickme', Arr::get($button->toArray(), 'payload'));
+    }
+
+    /**
+     * @test
+     **/
+    public function it_can_set_image_url()
+    {
+        $button = new QuickReplyButton('click me');
+        $button->imageUrl('https://botman.io/img/logo.png');
+
+        $this->assertSame('https://botman.io/img/logo.png', Arr::get($button->toArray(), 'image_url'));
+    }
+}

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Drivers;
 
+use BotMan\Drivers\Facebook\Extensions\QuickReplyButton;
 use Mockery as m;
 use BotMan\BotMan\Http\Curl;
 use PHPUnit_Framework_TestCase;
@@ -538,6 +539,49 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
                 ],
                 'access_token' => 'Foo',
             ])->andReturn(new Response());
+
+        $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
+        $request->shouldReceive('getContent')->andReturn('[]');
+
+        $driver = new FacebookDriver($request, [
+            'facebook' => [
+                'token' => 'Foo',
+            ],
+        ], $htmlInterface);
+
+        $message = new IncomingMessage('', '1234567890', '');
+        $driver->sendPayload($driver->buildServicePayload($question, $message));
+    }
+
+    /** @test */
+    public function it_can_reply_quick_replies_with_special_types()
+    {
+        $question = Question::create('How are you doing?')
+            ->addAction(QuickReplyButton::create()->type('user_email'))
+            ->addAction(QuickReplyButton::create()->type('location'))
+            ->addAction(QuickReplyButton::create()->type('user_phone_number'));
+
+        $htmlInterface = m::mock(Curl::class);
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+            'recipient' => [
+                'id' => '1234567890',
+            ],
+            'message' => [
+                'text' => 'How are you doing?',
+                'quick_replies' => [
+                    [
+                        'content_type' => 'user_email',
+                    ],
+                    [
+                        'content_type' => 'location',
+                    ],
+                    [
+                        'content_type' => 'user_phone_number',
+                    ],
+                ],
+            ],
+            'access_token' => 'Foo',
+        ])->andReturn(new Response());
 
         $request = m::mock(\Symfony\Component\HttpFoundation\Request::class.'[getContent]');
         $request->shouldReceive('getContent')->andReturn('[]');

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Drivers;
 
-use BotMan\Drivers\Facebook\Extensions\QuickReplyButton;
 use Mockery as m;
 use BotMan\BotMan\Http\Curl;
 use PHPUnit_Framework_TestCase;
@@ -20,6 +19,7 @@ use BotMan\Drivers\Facebook\Events\MessagingOptins;
 use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\Drivers\Facebook\Events\MessagingReferrals;
 use BotMan\Drivers\Facebook\Events\MessagingDeliveries;
+use BotMan\Drivers\Facebook\Extensions\QuickReplyButton;
 use BotMan\Drivers\Facebook\Exceptions\FacebookException;
 use BotMan\Drivers\Facebook\Events\MessagingCheckoutUpdates;
 


### PR DESCRIPTION
This PR adds the possibility to send the new quick reply types `location`, `user_email` and `user_phone_number`. ([More info here](https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies))

This is how we could send `QuickReplies` before: (and is still possible)
```php
$bot->reply(Question::create('Question:')->addButton(Button::create('Search')->value('search')));

$bot->reply(Question::create('Question:')->addAction(Button::create('test')->value('test')));
```

Now you get the same result with the new `QuickReplyButton` class:
```php
$bot->reply(Question::create('Question:')->addAction(QuickReplyButton::create('Search')->payload('search')));
```

And additionally now for the new `QuickReply types`:
```php
$bot->reply(Question::create('How are you doing?')
        ->addAction(QuickReplyButton::create()->type('user_email'))
        ->addAction(QuickReplyButton::create()->type('location'))
        ->addAction(QuickReplyButton::create()->type('user_phone_number')));
````

**What I am not satisfied with is:**

1. Maybe it would be nicer to create own method for `createLocation`, `createUserEmail` and `createUserPhoneNumber` but I tried to make it consistent with other templates and `create` normally takes the title.

2. The `convertQuestion` method from the FacebookDriver now looks a little bit messy because it needs to support both button types. Maybe it would be nicer to use a `QuickReply` class instead of the `Question` one. But maybe it is ok so for now.
