### PR TITLE
Graph API Upgrade to v3.0

### DIFF
--- a/src/Commands/AddGreetingText.php
+++ b/src/Commands/AddGreetingText.php
@@ -52,7 +52,7 @@ class AddGreetingText extends Command
         }
 
         $response = $this->http->post(
-            'https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('botman.facebook.token'),
+            'https://graph.facebook.com/v3.0/me/messenger_profile?access_token='.config('botman.facebook.token'),
             [], $payload);
 
         $responseObject = json_decode($response->getContent());

--- a/src/Commands/AddPersistentMenu.php
+++ b/src/Commands/AddPersistentMenu.php
@@ -51,7 +51,7 @@ class AddPersistentMenu extends Command
             exit;
         }
 
-        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('botman.facebook.token'),
+        $response = $this->http->post('https://graph.facebook.com/v3.0/me/messenger_profile?access_token='.config('botman.facebook.token'),
             [], $payload);
 
         $responseObject = json_decode($response->getContent());

--- a/src/Commands/AddStartButtonPayload.php
+++ b/src/Commands/AddStartButtonPayload.php
@@ -52,7 +52,7 @@ class AddStartButtonPayload extends Command
         }
 
         $response = $this->http->post(
-            'https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('botman.facebook.token'),
+            'https://graph.facebook.com/v3.0/me/messenger_profile?access_token='.config('botman.facebook.token'),
             [],
             [
                 'get_started' => [

--- a/src/Commands/WhitelistDomains.php
+++ b/src/Commands/WhitelistDomains.php
@@ -51,7 +51,7 @@ class WhitelistDomains extends Command
             exit;
         }
 
-        $response = $this->http->post('https://graph.facebook.com/v2.6/me/messenger_profile?access_token='.config('botman.facebook.token'),
+        $response = $this->http->post('https://graph.facebook.com/v3.0/me/messenger_profile?access_token='.config('botman.facebook.token'),
             [], ['whitelisted_domains' => $payload]);
 
         $responseObject = json_decode($response->getContent());

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -66,7 +66,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     /** @var DriverEventInterface */
     protected $driverEvent;
 
-    protected $facebookProfileEndpoint = 'https://graph.facebook.com/v2.6/';
+    protected $facebookProfileEndpoint = 'https://graph.facebook.com/v3.0/';
 
     /** @var bool If the incoming request is a FB postback */
     protected $isPostback = false;

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -202,7 +202,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $facebookResponse = '{"first_name":"John","last_name":"Doe","profile_pic":"https://facebook.com/profilepic","locale":"en_US","timezone":2,"gender":"male","is_payment_enabled":true}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v2.6/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response($facebookResponse));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response($facebookResponse));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $message = $driver->getMessages()[0];
@@ -227,7 +227,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v2.6/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response('{}'));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response('{}'));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $driver->getMessages()[0];
@@ -298,7 +298,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -347,7 +347,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -380,7 +380,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -475,7 +475,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $question = Question::create('How are you doing?')->addButton(Button::create('Great')->value('great'))->addButton(Button::create('Good')->value('good'));
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -519,7 +519,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $question = Question::create('How are you doing?')->addButton(Button::create('Great')->value('great')->additionalParameters(['foo' => 'bar']))->addButton(Button::create('Good')->value('good'));
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -567,7 +567,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
             ->addAction(QuickReplyButton::create()->type('user_phone_number'));
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
             'messaging_type' => 'RESPONSE',
             'recipient' => [
                 'id' => '1234567890',
@@ -659,7 +659,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -709,7 +709,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -764,7 +764,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -819,7 +819,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         ];
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'messaging_type' => 'RESPONSE',
                 'recipient' => [
                     'id' => '1234567890',
@@ -941,7 +941,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
     public function it_can_reply_mark_seen_sender_action()
     {
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v2.6/me/messages', [], [
+        $htmlInterface->shouldReceive('post')->once()->with('https://graph.facebook.com/v3.0/me/messages', [], [
                 'recipient' => [
                     'id' => '1234567890',
                 ],


### PR DESCRIPTION
Upgraded Graph API to v3.0 as v2.6 would be deprecated on July 13, 2018