### PR TITLE
Removing extra profile fields

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -419,7 +419,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         $messagingDetails = $this->event->get('messaging')[0];
 
         // field string available at Facebook
-        $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral';
+        $fields = 'first_name,last_name,profile_pic';
 
         // WORKPLACE (Facebook for companies)
         // if community isset in sender Object, it is a request done by workplace


### PR DESCRIPTION
Removed Gender, Locale, Timezone, payment enabled and ad referral as these need extra verification and submission to Facebook's app team even if it's not needed for just getting a users name. Basic user approval gives access to name.