### PR TITLE
new getUserWithField method

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -419,7 +419,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         $messagingDetails = $this->event->get('messaging')[0];
 
         // field string available at Facebook
-        $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral';
+        $fields = 'first_name,last_name,profile_pic';
 
         // WORKPLACE (Facebook for companies)
         // if community isset in sender Object, it is a request done by workplace

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -408,6 +408,32 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     }
 
     /**
+     * Retrieve specific User field information.
+     *
+     * @param Array $fields
+     * @param IncomingMessage $matchingMessage
+     * @return User
+     * @throws FacebookException
+     */
+    public function getUserWithFields(Array $fields, IncomingMessage $matchingMessage)
+    {
+        $messagingDetails = $this->event->get('messaging')[0];
+        // implode field array to create concatinated comma string
+        $fields = implode (",", $fields);
+        // WORKPLACE (Facebook for companies)
+        // if community isset in sender Object, it is a request done by workplace
+        if (isset($messagingDetails['sender']['community'])) {
+            $fields = 'first_name,last_name,email,title,department,employee_number,primary_phone,primary_address,picture,link,locale,name,name_format,updated_time';
+        }
+        $userInfoData = $this->http->get($this->facebookProfileEndpoint.$matchingMessage->getSender().'?fields='.$fields.'&access_token='.$this->config->get('token'));
+        $this->throwExceptionIfResponseNotOk($userInfoData);
+        $userInfo = json_decode($userInfoData->getContent(), true);
+        $firstName = $userInfo['first_name'] ?? null;
+        $lastName = $userInfo['last_name'] ?? null;
+        return new User($matchingMessage->getSender(), $firstName, $lastName, null, $userInfo);
+    }
+
+    /**
      * Retrieve User information.
      *
      * @param IncomingMessage $matchingMessage

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -445,7 +445,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         $messagingDetails = $this->event->get('messaging')[0];
 
         // field string available at Facebook
-        $fields = 'first_name,last_name,profile_pic';
+        $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral';
 
         // WORKPLACE (Facebook for companies)
         // if community isset in sender Object, it is a request done by workplace

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -222,6 +222,21 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_returns_the_user_first_name()
+    {
+        $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
+        $facebookResponse = '{"first_name":"John"}';
+        $htmlInterface = m::mock(Curl::class);
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=first_name&access_token=Foo')->andReturn(new Response($facebookResponse));
+        $driver = $this->getDriver($request, null, '', $htmlInterface);
+        $message = $driver->getMessages()[0];
+        $user = $driver->getUserWithFields(['first_name'],$message);
+        $this->assertSame($user->getId(), '1433960459967306');
+        $this->assertEquals('John', $user->getFirstName());
+        $this->assertEquals(json_decode($facebookResponse, true), $user->getInfo());
+    }
+
+    /** @test */
     public function it_throws_exception_in_get_user()
     {
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';


### PR DESCRIPTION
new method to bypass need for submission of extra fields as per Facebook's new rules. Allows for the grabbing on `first_name`, `last_name` and `profile_picture` using basic permissions. More fields can be passed if permissions have been approved. 

Example usage: `$user = $bot->getUserWithFields(['first_name','last_name']); echo $user->getFirstName();`