### PR TITLE
Only call for default no-permission user fields

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -457,7 +457,6 @@ class FacebookDriver extends HttpDriver implements VerifiesService
 
         $userInfoData = $this->http->get($this->facebookProfileEndpoint.$matchingMessage->getSender().'?fields='.$fields.'&access_token='.$this->config->get('token'));
 
-
         $this->throwExceptionIfResponseNotOk($userInfoData);
         $userInfo = json_decode($userInfoData->getContent(), true);
 

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -447,7 +447,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         $messagingDetails = $this->event->get('messaging')[0];
 
         // field string available at Facebook
-        $fields = 'first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral';
+        $fields = 'name,first_name,last_name,profile_pic';
 
         // WORKPLACE (Facebook for companies)
         // if community isset in sender Object, it is a request done by workplace
@@ -456,6 +456,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         }
 
         $userInfoData = $this->http->get($this->facebookProfileEndpoint.$matchingMessage->getSender().'?fields='.$fields.'&access_token='.$this->config->get('token'));
+
 
         $this->throwExceptionIfResponseNotOk($userInfoData);
         $userInfo = json_decode($userInfoData->getContent(), true);

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -202,7 +202,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $facebookResponse = '{"first_name":"John","last_name":"Doe","profile_pic":"https://facebook.com/profilepic","locale":"en_US","timezone":2,"gender":"male","is_payment_enabled":true}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response($facebookResponse));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name,profile_pic&access_token=Foo')->andReturn(new Response($facebookResponse));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $message = $driver->getMessages()[0];
@@ -242,7 +242,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=first_name,last_name,profile_pic,locale,timezone,gender,is_payment_enabled,last_ad_referral&access_token=Foo')->andReturn(new Response('{}'));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name,profile_pic&access_token=Foo')->andReturn(new Response('{}'));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $driver->getMessages()[0];


### PR DESCRIPTION
This PR removes the fields from the get user method, where FB now needs permission. Now only the default `no-permission` fields are being requested. For other fields, you can use the `getUserWithFields` method, if you have the right permissions. 