### PR TITLE
Add I/O type hinting, remove duplicate code, improve Docblock, add some optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "botman/botman": "~2.1|~3.0"
+        "botman/botman": "~2.1|~3.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "botman/studio-addons": "~1.0",

--- a/src/Commands/AddGreetingText.php
+++ b/src/Commands/AddGreetingText.php
@@ -57,10 +57,12 @@ class AddGreetingText extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Greeting text was set.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/AddPersistentMenu.php
+++ b/src/Commands/AddPersistentMenu.php
@@ -56,10 +56,12 @@ class AddPersistentMenu extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Facebook menu was set.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/AddStartButtonPayload.php
+++ b/src/Commands/AddStartButtonPayload.php
@@ -63,10 +63,12 @@ class AddStartButtonPayload extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Get Started payload was set to: '.$payload);
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/Nlp.php
+++ b/src/Commands/Nlp.php
@@ -49,14 +49,16 @@ class Nlp extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             if ($this->option('disable')) {
                 $this->info('NLP was disabled.');
             } else {
                 $this->info('NLP was enabled.');
             }
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/WhitelistDomains.php
+++ b/src/Commands/WhitelistDomains.php
@@ -56,10 +56,12 @@ class WhitelistDomains extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Domains where whitelisted.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Events/FacebookEvent.php
+++ b/src/Events/FacebookEvent.php
@@ -21,7 +21,7 @@ abstract class FacebookEvent implements DriverEventInterface
      *
      * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 
     /**
      * Return the event payload.

--- a/src/Events/MessagingCheckoutUpdates.php
+++ b/src/Events/MessagingCheckoutUpdates.php
@@ -9,7 +9,7 @@ class MessagingCheckoutUpdates extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_checkout_updates';
     }

--- a/src/Events/MessagingDeliveries.php
+++ b/src/Events/MessagingDeliveries.php
@@ -9,7 +9,7 @@ class MessagingDeliveries extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_deliveries';
     }

--- a/src/Events/MessagingOptins.php
+++ b/src/Events/MessagingOptins.php
@@ -9,7 +9,7 @@ class MessagingOptins extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_optins';
     }

--- a/src/Events/MessagingPostbacks.php
+++ b/src/Events/MessagingPostbacks.php
@@ -9,7 +9,7 @@ class MessagingPostbacks extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_postbacks';
     }

--- a/src/Events/MessagingReads.php
+++ b/src/Events/MessagingReads.php
@@ -9,7 +9,7 @@ class MessagingReads extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_reads';
     }

--- a/src/Events/MessagingReferrals.php
+++ b/src/Events/MessagingReferrals.php
@@ -9,7 +9,7 @@ class MessagingReferrals extends FacebookEvent
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return 'messaging_referrals';
     }

--- a/src/Extensions/ButtonTemplate.php
+++ b/src/Extensions/ButtonTemplate.php
@@ -7,31 +7,42 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class ButtonTemplate implements JsonSerializable, WebAccess
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $text;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $buttons = [];
 
     /**
-     * @param $text
-     * @return static
+     * @param string $text
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
-    public static function create($text)
+    public static function create(string $text): self
     {
         return new static($text);
     }
 
-    public function __construct($text)
+    /**
+     * ButtonTemplate constructor.
+     *
+     * @param string $text
+     */
+    public function __construct(string $text)
     {
         $this->text = $text;
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
-    public function addButton(ElementButton $button)
+    public function addButton(ElementButton $button): self
     {
         $this->buttons[] = $button->toArray();
 
@@ -40,9 +51,10 @@ class ButtonTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
-    public function addButtons(array $buttons)
+    public function addButtons(array $buttons): self
     {
         foreach ($buttons as $button) {
             if ($button instanceof ElementButton) {
@@ -56,7 +68,7 @@ class ButtonTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'attachment' => [
@@ -73,7 +85,7 @@ class ButtonTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -84,7 +96,7 @@ class ButtonTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver()
+    public function toWebDriver(): array
     {
         return [
             'type' => 'buttons',

--- a/src/Extensions/Element.php
+++ b/src/Extensions/Element.php
@@ -6,29 +6,42 @@ use JsonSerializable;
 
 class Element implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $title;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $image_url;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $item_url;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $subtitle;
 
-    /** @var object */
+    /**
+     * @var object
+     */
     protected $buttons;
 
-    /** @var object */
+    /**
+     * @var object
+     */
     protected $default_action;
 
     /**
-     * @param $title
-     * @return static
+     * @param string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public static function create($title)
+    public static function create(string $title): self
     {
         return new static($title);
     }
@@ -36,16 +49,17 @@ class Element implements JsonSerializable
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
 
     /**
      * @param string $title
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function title($title)
+    public function title(string $title): self
     {
         $this->title = $title;
 
@@ -54,9 +68,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $subtitle
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function subtitle($subtitle)
+    public function subtitle(string $subtitle): self
     {
         $this->subtitle = $subtitle;
 
@@ -65,9 +80,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $image_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function image($image_url)
+    public function image(string $image_url): self
     {
         $this->image_url = $image_url;
 
@@ -76,9 +92,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $item_url
+     *
      * @return $this
      */
-    public function itemUrl($item_url)
+    public function itemUrl(string $item_url): self
     {
         $this->item_url = $item_url;
 
@@ -86,10 +103,11 @@ class Element implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function addButton(ElementButton $button)
+    public function addButton(ElementButton $button): self
     {
         $this->buttons[] = $button->toArray();
 
@@ -98,15 +116,14 @@ class Element implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function addButtons(array $buttons)
+    public function addButtons(array $buttons): self
     {
-        if (isset($buttons) && is_array($buttons)) {
-            foreach ($buttons as $button) {
-                if ($button instanceof ElementButton) {
-                    $this->buttons[] = $button->toArray();
-                }
+        foreach ($buttons as $button) {
+            if ($button instanceof ElementButton) {
+                $this->buttons[] = $button->toArray();
             }
         }
 
@@ -114,11 +131,11 @@ class Element implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $defaultAction
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $defaultAction
      *
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function defaultAction(ElementButton $defaultAction)
+    public function defaultAction(ElementButton $defaultAction): self
     {
         $defaultAction->type(ElementButton::TYPE_WEB_URL);
         $this->default_action = $defaultAction->toArray();
@@ -129,7 +146,7 @@ class Element implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'title' => $this->title,
@@ -144,7 +161,7 @@ class Element implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ElementButton.php
+++ b/src/Extensions/ElementButton.php
@@ -4,33 +4,6 @@ namespace BotMan\Drivers\Facebook\Extensions;
 
 class ElementButton
 {
-    /** @var string */
-    protected $title;
-
-    /** @var string */
-    protected $type = self::TYPE_WEB_URL;
-
-    /** @var string */
-    protected $url;
-
-    /** @var string */
-    protected $fallback_url;
-
-    /** @var string */
-    protected $payload;
-
-    /** @var string */
-    protected $webview_height_ratio = self::RATIO_FULL;
-
-    /** @var string */
-    protected $webview_share_button;
-
-    /** @var bool */
-    protected $messenger_extensions = false;
-
-    /** @var GenericTemplate */
-    protected $shareContents;
-
     const TYPE_ACCOUNT_LINK = 'account_link';
     const TYPE_ACCOUNT_UNLINK = 'account_unlink';
     const TYPE_WEB_URL = 'web_url';
@@ -44,28 +17,76 @@ class ElementButton
     const RATIO_FULL = 'full';
 
     /**
-     * @param string $title
-     * @return static
+     * @var string
      */
-    public static function create($title)
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $type = self::TYPE_WEB_URL;
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var string
+     */
+    protected $fallback_url;
+
+    /**
+     * @var string
+     */
+    protected $payload;
+
+    /**
+     * @var string
+     */
+    protected $webview_height_ratio = self::RATIO_FULL;
+
+    /**
+     * @var string
+     */
+    protected $webview_share_button;
+
+    /**
+     * @var bool
+     */
+    protected $messenger_extensions = false;
+
+    /**
+     * @var GenericTemplate
+     */
+    protected $shareContents;
+
+    /**
+     * @param null|string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
+     */
+    public static function create($title = null): self
     {
         return new static($title);
     }
 
     /**
-     * @param string $title
+     * @param null|string $title
      */
-    public function __construct($title)
+    public function __construct($title = null)
     {
         $this->title = $title;
     }
 
     /**
      * Set the button URL.
+     *
      * @param string $url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function url($url)
+    public function url(string $url): self
     {
         $this->url = $url;
 
@@ -74,10 +95,12 @@ class ElementButton
 
     /**
      * Set the button type.
+     *
      * @param string $type
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function type($type)
+    public function type(string $type): self
     {
         $this->type = $type;
 
@@ -85,10 +108,11 @@ class ElementButton
     }
 
     /**
-     * @param $payload
-     * @return $this
+     * @param string $payload
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function payload($payload)
+    public function payload(string $payload): self
     {
         $this->payload = $payload;
 
@@ -97,9 +121,10 @@ class ElementButton
 
     /**
      * @param string $fallback_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function fallbackUrl($fallback_url)
+    public function fallbackUrl(string $fallback_url): self
     {
         $this->fallback_url = $fallback_url;
 
@@ -108,9 +133,10 @@ class ElementButton
 
     /**
      * enable messenger extensions.
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function enableExtensions()
+    public function enableExtensions(): self
     {
         $this->messenger_extensions = true;
 
@@ -118,9 +144,9 @@ class ElementButton
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function disableShare()
+    public function disableShare(): self
     {
         $this->webview_share_button = 'HIDE';
 
@@ -128,9 +154,9 @@ class ElementButton
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function removeHeightRatio()
+    public function removeHeightRatio(): self
     {
         $this->webview_height_ratio = null;
 
@@ -139,10 +165,12 @@ class ElementButton
 
     /**
      * Set ratio to one of RATIO_COMPACT, RATIO_TALL, RATIO_FULL.
+     *
      * @param string $ratio
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function heightRatio($ratio = self::RATIO_FULL)
+    public function heightRatio(string $ratio = self::RATIO_FULL): self
     {
         $this->webview_height_ratio = $ratio;
 
@@ -153,10 +181,12 @@ class ElementButton
      * Optional. The message that you wish the recipient of the share to see,
      * if it is different from the one this button is attached to.
      * The format follows that used in Send API, but must be a generic template with up to one URL button.
+     *
      * @param GenericTemplate $shareContents
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function shareContents($shareContents)
+    public function shareContents(GenericTemplate $shareContents): self
     {
         $this->shareContents = $shareContents;
 
@@ -166,7 +196,7 @@ class ElementButton
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $buttonArray = [
             'type' => $this->type,
@@ -184,10 +214,10 @@ class ElementButton
             }
 
             if ($this->type === self::TYPE_WEB_URL) {
-                if (! is_null($this->webview_height_ratio)) {
+                if ($this->webview_height_ratio !== null) {
                     $buttonArray['webview_height_ratio'] = $this->webview_height_ratio;
                 }
-                if (! is_null($this->webview_share_button)) {
+                if ($this->webview_share_button !== null) {
                     $buttonArray['webview_share_button'] = $this->webview_share_button;
                 }
 
@@ -196,7 +226,7 @@ class ElementButton
                     $buttonArray['fallback_url'] = $this->fallback_url ?: $this->url;
                 }
             }
-        } elseif ($this->type == self::TYPE_SHARE && ! is_null($this->shareContents)) {
+        } elseif ($this->type === self::TYPE_SHARE && $this->shareContents !== null) {
             $buttonArray['share_contents'] = $this->shareContents->toArray();
         }
 
@@ -206,7 +236,7 @@ class ElementButton
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -10,31 +10,38 @@ class GenericTemplate implements JsonSerializable, WebAccess
     const RATIO_HORIZONTAL = 'horizontal';
     const RATIO_SQUARE = 'square';
 
-    /** @var array */
+    /**
+     * @var array
+     */
     private static $allowedRatios = [
         self::RATIO_HORIZONTAL,
         self::RATIO_SQUARE,
     ];
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $elements = [];
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $imageAspectRatio = self::RATIO_HORIZONTAL;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
-    public static function create()
+    public static function create(): self
     {
         return new static;
     }
 
     /**
-     * @param Element $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\Element $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
-    public function addElement(Element $element)
+    public function addElement(Element $element): self
     {
         $this->elements[] = $element->toArray();
 
@@ -43,9 +50,10 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
-    public function addElements(array $elements)
+    public function addElements(array $elements): self
     {
         foreach ($elements as $element) {
             if ($element instanceof Element) {
@@ -58,11 +66,12 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param string $ratio
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
-    public function addImageAspectRatio($ratio)
+    public function addImageAspectRatio(string $ratio): self
     {
-        if (in_array($ratio, self::$allowedRatios)) {
+        if (\ in_array($ratio, self::$allowedRatios, true)) {
             $this->imageAspectRatio = $ratio;
         }
 
@@ -72,7 +81,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'attachment' => [
@@ -89,7 +98,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -100,7 +109,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver()
+    public function toWebDriver(): array
     {
         return [
             'type' => 'list',

--- a/src/Extensions/ListTemplate.php
+++ b/src/Extensions/ListTemplate.php
@@ -7,28 +7,35 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class ListTemplate implements JsonSerializable, WebAccess
 {
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $elements = [];
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $globalButton;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $top_element_style = 'large';
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
-    public static function create()
+    public static function create(): self
     {
         return new static;
     }
 
     /**
-     * @param Element $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\Element $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
-    public function addElement(Element $element)
+    public function addElement(Element $element): self
     {
         $this->elements[] = $element->toArray();
 
@@ -37,9 +44,10 @@ class ListTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
-    public function addElements(array $elements)
+    public function addElements(array $elements): self
     {
         foreach ($elements as $element) {
             if ($element instanceof Element) {
@@ -51,10 +59,11 @@ class ListTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
-    public function addGlobalButton(ElementButton $button)
+    public function addGlobalButton(ElementButton $button): self
     {
         $this->globalButton = $button->toArray();
 
@@ -62,9 +71,9 @@ class ListTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
-    public function useCompactView()
+    public function useCompactView(): self
     {
         $this->top_element_style = 'compact';
 
@@ -74,7 +83,7 @@ class ListTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'attachment' => [
@@ -94,7 +103,7 @@ class ListTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -105,7 +114,7 @@ class ListTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver()
+    public function toWebDriver(): array
     {
         return [
             'type' => 'list',

--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -6,37 +6,47 @@ use JsonSerializable;
 
 class MediaAttachmentElement implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $media_type;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $attachment_id;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $buttons;
 
     /**
-     * @param $mediaType
-     * @return static
+     * @param string $mediaType
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public static function create($mediaType)
+    public static function create(string $mediaType): self
     {
         return new static($mediaType);
     }
 
     /**
-     * @param $mediaType
+     * MediaAttachmentElement constructor.
+     *
+     * @param string $mediaType
      */
-    public function __construct($mediaType)
+    public function __construct(string $mediaType)
     {
         $this->media_type = $mediaType;
     }
 
     /**
-     * @param $attachmentId
-     * @return $this
+     * @param string $attachmentId
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public function attachmentId($attachmentId)
+    public function attachmentId(string $attachmentId): self
     {
         $this->attachment_id = $attachmentId;
 
@@ -44,10 +54,11 @@ class MediaAttachmentElement implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public function addButton(ElementButton $button)
+    public function addButton(ElementButton $button): self
     {
         $this->buttons[] = $button->toArray();
 
@@ -56,9 +67,10 @@ class MediaAttachmentElement implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public function addButtons(array $buttons)
+    public function addButtons(array $buttons): self
     {
         foreach ($buttons as $button) {
             if ($button instanceof ElementButton) {
@@ -72,7 +84,7 @@ class MediaAttachmentElement implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'media_type' => $this->media_type,
@@ -84,7 +96,7 @@ class MediaAttachmentElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/MediaTemplate.php
+++ b/src/Extensions/MediaTemplate.php
@@ -7,27 +7,32 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class MediaTemplate implements JsonSerializable, WebAccess
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $mediaType;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $elements = [];
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaTemplate
      */
-    public static function create()
+    public static function create(): self
     {
         return new static();
     }
 
     /**
      * @param $element
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaTemplate
      */
-    public function element($element)
+    public function element($element): self
     {
-        $this->elements = [$element->toArray()];
+        $this->elements[] = $element->toArray();
 
         return $this;
     }
@@ -35,7 +40,7 @@ class MediaTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'attachment' => [
@@ -51,7 +56,7 @@ class MediaTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -62,7 +67,7 @@ class MediaTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver()
+    public function toWebDriver(): array
     {
         return [
             'type' => $this->mediaType,

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -6,37 +6,47 @@ use JsonSerializable;
 
 class MediaUrlElement implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $media_type;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $url;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $buttons;
 
     /**
-     * @param $mediaType
-     * @return static
+     * @param string $mediaType
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public static function create($mediaType)
+    public static function create(string $mediaType): self
     {
         return new static($mediaType);
     }
 
     /**
-     * @param $mediaType
+     * MediaUrlElement constructor.
+     *
+     * @param string $mediaType
      */
-    public function __construct($mediaType)
+    public function __construct(string $mediaType)
     {
         $this->media_type = $mediaType;
     }
 
     /**
-     * @param $url
-     * @return $this
+     * @param string $url
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public function url($url)
+    public function url(string $url): self
     {
         $this->url = $url;
 
@@ -44,10 +54,11 @@ class MediaUrlElement implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public function addButton(ElementButton $button)
+    public function addButton(ElementButton $button): self
     {
         $this->buttons[] = $button->toArray();
 
@@ -56,9 +67,10 @@ class MediaUrlElement implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public function addButtons(array $buttons)
+    public function addButtons(array $buttons): self
     {
         foreach ($buttons as $button) {
             if ($button instanceof ElementButton) {
@@ -72,7 +84,7 @@ class MediaUrlElement implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'media_type' => $this->media_type,
@@ -84,7 +96,7 @@ class MediaUrlElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/QuickReplyButton.php
+++ b/src/Extensions/QuickReplyButton.php
@@ -6,25 +6,34 @@ use BotMan\BotMan\Interfaces\QuestionActionInterface;
 
 class QuickReplyButton implements QuestionActionInterface
 {
-    /** @var string */
-    protected $contentType = self::TYPE_TEXT;
-
-    /** @var string */
-    protected $title;
-
-    /** @var string */
-    protected $payload;
-
-    /** @var string */
-    protected $imageUrl;
-
     const TYPE_TEXT = 'text';
 
     /**
-     * @param string $title
-     * @return static
+     * @var string
      */
-    public static function create($title = '')
+    protected $contentType = self::TYPE_TEXT;
+
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $payload;
+
+    /**
+     * @var string
+     */
+    protected $imageUrl;
+
+    /**
+     * @param string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
+     */
+    public static function create(string $title = ''): self
     {
         return new static($title);
     }
@@ -32,7 +41,7 @@ class QuickReplyButton implements QuestionActionInterface
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
@@ -41,9 +50,10 @@ class QuickReplyButton implements QuestionActionInterface
      * Set the button type.
      *
      * @param string $type
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function type($type)
+    public function type(string $type): self
     {
         $this->contentType = $type;
 
@@ -51,10 +61,11 @@ class QuickReplyButton implements QuestionActionInterface
     }
 
     /**
-     * @param $payload
-     * @return $this
+     * @param string $payload
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function payload($payload)
+    public function payload(string $payload): self
     {
         $this->payload = $payload;
 
@@ -62,12 +73,11 @@ class QuickReplyButton implements QuestionActionInterface
     }
 
     /**
-     * Set the button URL.
-     *
      * @param string $url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function imageUrl($url)
+    public function imageUrl(string $url): self
     {
         $this->imageUrl = $url;
 
@@ -77,11 +87,11 @@ class QuickReplyButton implements QuestionActionInterface
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $buttonArray = [];
 
-        if ($this->contentType === 'text') {
+        if ($this->contentType === self::TYPE_TEXT) {
             $buttonArray = [
                 'content_type' => $this->contentType,
                 'title' => $this->title,
@@ -98,7 +108,7 @@ class QuickReplyButton implements QuestionActionInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptAddress.php
+++ b/src/Extensions/ReceiptAddress.php
@@ -6,37 +6,50 @@ use JsonSerializable;
 
 class ReceiptAddress implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $street_1;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $street_2;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $city;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $postal_code;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $state;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $country;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public static function create()
+    public static function create(): self
     {
         return new static;
     }
 
     /**
      * @param string $street
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function street1($street)
+    public function street1(string $street): self
     {
         $this->street_1 = $street;
 
@@ -45,9 +58,10 @@ class ReceiptAddress implements JsonSerializable
 
     /**
      * @param string $street
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function street2($street)
+    public function street2(string $street): self
     {
         $this->street_2 = $street;
 
@@ -55,10 +69,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $city
-     * @return $this
+     * @param string $city
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function city($city)
+    public function city(string $city): self
     {
         $this->city = $city;
 
@@ -66,10 +81,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $postalCode
-     * @return $this
+     * @param string $postalCode
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function postalCode($postalCode)
+    public function postalCode(string $postalCode): self
     {
         $this->postal_code = $postalCode;
 
@@ -77,10 +93,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $state
-     * @return $this
+     * @param string $state
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function state($state)
+    public function state(string $state): self
     {
         $this->state = $state;
 
@@ -88,10 +105,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param string $country
+     * @param $country
+     *
      * @return $this
      */
-    public function country($country)
+    public function country(string $country): self
     {
         $this->country = $country;
 
@@ -101,7 +119,7 @@ class ReceiptAddress implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'street_1' => $this->street_1,
@@ -116,7 +134,7 @@ class ReceiptAddress implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptAdjustment.php
+++ b/src/Extensions/ReceiptAdjustment.php
@@ -6,35 +6,42 @@ use JsonSerializable;
 
 class ReceiptAdjustment implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $name;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $amount;
 
     /**
-     * @param $name
-     * @return static
+     * @param string $name
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment
      */
-    public static function create($name)
+    public static function create(string $name): self
     {
         return new static($name);
     }
 
     /**
      * ReceiptAdjustment constructor.
-     * @param $name
+     *
+     * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @param string $amount
-     * @return $this
+     * @param float $amount
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment
      */
-    public function amount($amount)
+    public function amount(float $amount): self
     {
         $this->amount = $amount;
 
@@ -44,7 +51,7 @@ class ReceiptAdjustment implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'name' => $this->name,
@@ -55,7 +62,7 @@ class ReceiptAdjustment implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptElement.php
+++ b/src/Extensions/ReceiptElement.php
@@ -6,29 +6,42 @@ use JsonSerializable;
 
 class ReceiptElement implements JsonSerializable
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $title;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $subtitle;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $quantity;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $price = 0;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $currency;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $image_url;
 
     /**
-     * @param $title
-     * @return static
+     * @param string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public static function create($title)
+    public static function create(string $title): self
     {
         return new static($title);
     }
@@ -36,16 +49,17 @@ class ReceiptElement implements JsonSerializable
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
 
     /**
      * @param string $subtitle
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function subtitle($subtitle)
+    public function subtitle(string $subtitle): self
     {
         $this->subtitle = $subtitle;
 
@@ -53,10 +67,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $quantity
-     * @return $this
+     * @param int $quantity
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function quantity($quantity)
+    public function quantity(int $quantity): self
     {
         $this->quantity = $quantity;
 
@@ -64,10 +79,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $price
-     * @return $this
+     * @param float $price
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function price($price)
+    public function price(float $price): self
     {
         $this->price = $price;
 
@@ -75,10 +91,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $currency
-     * @return $this
+     * @param string $currency
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function currency($currency)
+    public function currency(string $currency): self
     {
         $this->currency = $currency;
 
@@ -87,9 +104,10 @@ class ReceiptElement implements JsonSerializable
 
     /**
      * @param string $image_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function image($image_url)
+    public function image(string $image_url): self
     {
         $this->image_url = $image_url;
 
@@ -99,7 +117,7 @@ class ReceiptElement implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'title' => $this->title,
@@ -114,7 +132,7 @@ class ReceiptElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptSummary.php
+++ b/src/Extensions/ReceiptSummary.php
@@ -6,31 +6,40 @@ use JsonSerializable;
 
 class ReceiptSummary implements JsonSerializable
 {
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $subtotal;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $shipping_cost;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $total_tax;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $total_cost;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public static function create()
+    public static function create(): self
     {
         return new static;
     }
 
     /**
-     * @param string $subtotal
-     * @return $this
+     * @param float $subtotal
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function subtotal($subtotal)
+    public function subtotal(float $subtotal): self
     {
         $this->subtotal = $subtotal;
 
@@ -38,10 +47,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param string $shippingCost
-     * @return $this
+     * @param float $shippingCost
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function shippingCost($shippingCost)
+    public function shippingCost(float $shippingCost): self
     {
         $this->shipping_cost = $shippingCost;
 
@@ -49,10 +59,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param $totalTax
-     * @return $this
+     * @param float $totalTax
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function totalTax($totalTax)
+    public function totalTax(float $totalTax): self
     {
         $this->total_tax = $totalTax;
 
@@ -60,10 +71,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param $totalCost
-     * @return $this
+     * @param float $totalCost
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function totalCost($totalCost)
+    public function totalCost(float $totalCost): self
     {
         $this->total_cost = $totalCost;
 
@@ -73,7 +85,7 @@ class ReceiptSummary implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'subtotal' => $this->subtotal,
@@ -86,7 +98,7 @@ class ReceiptSummary implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptTemplate.php
+++ b/src/Extensions/ReceiptTemplate.php
@@ -7,37 +7,59 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class ReceiptTemplate implements JsonSerializable, WebAccess
 {
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $recipient_name;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $merchant_name;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $order_number;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $currency;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $payment_method;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $order_url;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $timestamp;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $elements = [];
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $address;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $summary;
 
-    /** @var array */
+    /**
+     * @var array
+     */
     protected $adjustments = [];
 
     /**
@@ -50,9 +72,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $name
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function recipientName($name)
+    public function recipientName(string $name): self
     {
         $this->recipient_name = $name;
 
@@ -61,9 +84,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $name
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function merchantName($name)
+    public function merchantName(string $name): self
     {
         $this->merchant_name = $name;
 
@@ -72,9 +96,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $orderNumber
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function orderNumber($orderNumber)
+    public function orderNumber(string $orderNumber): self
     {
         $this->order_number = $orderNumber;
 
@@ -83,9 +108,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $currency
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function currency($currency)
+    public function currency(string $currency): self
     {
         $this->currency = $currency;
 
@@ -94,9 +120,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $paymentMethod
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function paymentMethod($paymentMethod)
+    public function paymentMethod(string $paymentMethod): self
     {
         $this->payment_method = $paymentMethod;
 
@@ -105,9 +132,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $orderUrl
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function orderUrl($orderUrl)
+    public function orderUrl(string $orderUrl): self
     {
         $this->order_url = $orderUrl;
 
@@ -116,9 +144,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $timestamp
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function timestamp($timestamp)
+    public function timestamp(string $timestamp): self
     {
         $this->timestamp = $timestamp;
 
@@ -126,10 +155,11 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptElement $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptElement $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function addElement(ReceiptElement $element)
+    public function addElement(ReceiptElement $element): self
     {
         $this->elements[] = $element->toArray();
 
@@ -138,9 +168,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function addElements(array $elements)
+    public function addElements(array $elements): self
     {
         foreach ($elements as $element) {
             if ($element instanceof ReceiptElement) {
@@ -152,10 +183,11 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptAddress $address
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptAddress $address
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function addAddress(ReceiptAddress $address)
+    public function addAddress(ReceiptAddress $address): self
     {
         $this->address = $address->toArray();
 
@@ -163,10 +195,11 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptSummary $summary
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptSummary $summary
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function addSummary(ReceiptSummary $summary)
+    public function addSummary(ReceiptSummary $summary): self
     {
         $this->summary = $summary->toArray();
 
@@ -174,10 +207,11 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptAdjustment $adjustment
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment $adjustment
+     *
      * @return $this
      */
-    public function addAdjustment(ReceiptAdjustment $adjustment)
+    public function addAdjustment(ReceiptAdjustment $adjustment): self
     {
         $this->adjustments[] = $adjustment->toArray();
 
@@ -186,9 +220,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $adjustments
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function addAdjustments(array $adjustments)
+    public function addAdjustments(array $adjustments): self
     {
         foreach ($adjustments as $adjustment) {
             if ($adjustment instanceof ReceiptAdjustment) {
@@ -202,7 +237,7 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'attachment' => [
@@ -228,7 +263,7 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }
@@ -239,7 +274,7 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver()
+    public function toWebDriver(): array
     {
         return [
             'type' => 'receipt',

--- a/src/Extensions/User.php
+++ b/src/Extensions/User.php
@@ -2,32 +2,12 @@
 
 namespace BotMan\Drivers\Facebook\Extensions;
 
-use BotMan\BotMan\Interfaces\UserInterface;
 use BotMan\BotMan\Users\User as BotManUser;
 
-class User extends BotManUser implements UserInterface
+class User extends BotManUser
 {
     /**
-     * @var array
-     */
-    protected $user_info;
-
-    public function __construct(
-        $id = null,
-        $first_name = null,
-        $last_name = null,
-        $username = null,
-        array $user_info = []
-    ) {
-        $this->id = $id;
-        $this->first_name = $first_name;
-        $this->last_name = $last_name;
-        $this->username = $username;
-        $this->user_info = (array) $user_info;
-    }
-
-    /**
-     * @return string
+     * @return string|null
      */
     public function getProfilePic()
     {
@@ -42,7 +22,7 @@ class User extends BotManUser implements UserInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLocale()
     {
@@ -50,34 +30,34 @@ class User extends BotManUser implements UserInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getTimezone()
     {
-        return isset($this->user_info['timezone']) ? $this->user_info['timezone'] : null;
+        return $this->user_info['timezone'] ?? null;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getGender()
     {
-        return isset($this->user_info['gender']) ? $this->user_info['gender'] : null;
+        return $this->user_info['gender'] ?? null;
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getIsPaymentEnabled()
     {
-        return isset($this->user_info['is_payment_enabled']) ? $this->user_info['is_payment_enabled'] : null;
+        return $this->user_info['is_payment_enabled'] ?? null;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getLastAdReferral()
     {
-        return isset($this->user_info['last_ad_referral']) ? $this->user_info['last_ad_referral'] : null;
+        return $this->user_info['last_ad_referral'] ?? null;
     }
 }

--- a/src/FacebookAudioDriver.php
+++ b/src/FacebookAudioDriver.php
@@ -15,13 +15,13 @@ class FacebookAudioDriver extends FacebookDriver
      *
      * @return bool
      */
-    public function matchesRequest()
+    public function matchesRequest(): bool
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'audio';
+                    return isset($attachment['type']) && $attachment['type'] === 'audio';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookAudioDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Audio::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setAudio($this->getAudioUrls($msg));
@@ -59,7 +45,7 @@ class FacebookAudioDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,9 +56,10 @@ class FacebookAudioDriver extends FacebookDriver
      * Retrieve audio file urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the audio file.
      */
-    public function getAudioUrls(array $message)
+    public function getAudioUrls(array $message): array
     {
         return Collection::make($message['message']['attachments'])->where('type',
             'audio')->pluck('payload')->map(function ($item) {
@@ -83,7 +70,7 @@ class FacebookAudioDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
         return false;
     }
@@ -91,7 +78,7 @@ class FacebookAudioDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function hasMatchingEvent()
+    public function hasMatchingEvent(): bool
     {
         return false;
     }

--- a/src/FacebookFileDriver.php
+++ b/src/FacebookFileDriver.php
@@ -15,13 +15,13 @@ class FacebookFileDriver extends FacebookDriver
      *
      * @return bool
      */
-    public function matchesRequest()
+    public function matchesRequest(): bool
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'file';
+                    return isset($attachment['type']) && $attachment['type'] === 'file';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookFileDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(File::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setFiles($this->getFiles($msg));
@@ -59,7 +45,7 @@ class FacebookFileDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,9 +56,10 @@ class FacebookFileDriver extends FacebookDriver
      * Retrieve file urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the file.
      */
-    public function getFiles(array $message)
+    public function getFiles(array $message): array
     {
         return Collection::make($message['message']['attachments'])->where('type',
             'file')->pluck('payload')->map(function ($item) {
@@ -83,7 +70,7 @@ class FacebookFileDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
         return false;
     }
@@ -91,7 +78,7 @@ class FacebookFileDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function hasMatchingEvent()
+    public function hasMatchingEvent(): bool
     {
         return false;
     }

--- a/src/FacebookImageDriver.php
+++ b/src/FacebookImageDriver.php
@@ -15,13 +15,13 @@ class FacebookImageDriver extends FacebookDriver
      *
      * @return bool
      */
-    public function matchesRequest()
+    public function matchesRequest(): bool
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'image';
+                    return isset($attachment['type']) && $attachment['type'] === 'image';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookImageDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Image::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setImages($this->getImagesUrls($msg));
@@ -59,7 +45,7 @@ class FacebookImageDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,9 +56,10 @@ class FacebookImageDriver extends FacebookDriver
      * Retrieve image urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the image file.
      */
-    public function getImagesUrls(array $message)
+    public function getImagesUrls(array $message): array
     {
         return Collection::make($message['message']['attachments'])->where('type',
             'image')->pluck('payload')->map(function ($item) {
@@ -83,7 +70,7 @@ class FacebookImageDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
         return false;
     }
@@ -91,7 +78,7 @@ class FacebookImageDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function hasMatchingEvent()
+    public function hasMatchingEvent(): bool
     {
         return false;
     }

--- a/src/FacebookLocationDriver.php
+++ b/src/FacebookLocationDriver.php
@@ -15,13 +15,13 @@ class FacebookLocationDriver extends FacebookDriver
      *
      * @return bool
      */
-    public function matchesRequest()
+    public function matchesRequest(): bool
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'location';
+                    return isset($attachment['type']) && $attachment['type'] === 'location';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookLocationDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Location::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setLocation($this->getLocation($msg));
@@ -59,7 +45,7 @@ class FacebookLocationDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,9 +56,10 @@ class FacebookLocationDriver extends FacebookDriver
      * Retrieve location from an incoming message.
      *
      * @param array $messages
+     *
      * @return \BotMan\BotMan\Messages\Attachments\Location
      */
-    public function getLocation(array $messages)
+    public function getLocation(array $messages): Location
     {
         $data = Collection::make($messages['message']['attachments'])->where('type',
             'location')->pluck('payload')->first();
@@ -83,7 +70,7 @@ class FacebookLocationDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
         return false;
     }
@@ -91,7 +78,7 @@ class FacebookLocationDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function hasMatchingEvent()
+    public function hasMatchingEvent(): bool
     {
         return false;
     }

--- a/src/FacebookVideoDriver.php
+++ b/src/FacebookVideoDriver.php
@@ -15,13 +15,13 @@ class FacebookVideoDriver extends FacebookDriver
      *
      * @return bool
      */
-    public function matchesRequest()
+    public function matchesRequest(): bool
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'video';
+                    return isset($attachment['type']) && $attachment['type'] === 'video';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookVideoDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Video::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setVideos($this->getVideoUrls($msg));
@@ -59,7 +45,7 @@ class FacebookVideoDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -72,7 +58,7 @@ class FacebookVideoDriver extends FacebookDriver
      * @param array $message
      * @return array A download for the image file.
      */
-    public function getVideoUrls(array $message)
+    public function getVideoUrls(array $message): array
     {
         return Collection::make($message['message']['attachments'])->where('type',
             'video')->pluck('payload')->map(function ($item) {
@@ -83,7 +69,7 @@ class FacebookVideoDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function isConfigured()
+    public function isConfigured(): bool
     {
         return false;
     }
@@ -91,7 +77,7 @@ class FacebookVideoDriver extends FacebookDriver
     /**
      * @return bool
      */
-    public function hasMatchingEvent()
+    public function hasMatchingEvent(): bool
     {
         return false;
     }

--- a/src/Providers/FacebookServiceProvider.php
+++ b/src/Providers/FacebookServiceProvider.php
@@ -63,7 +63,7 @@ class FacebookServiceProvider extends ServiceProvider
     /**
      * @return bool
      */
-    protected function isRunningInBotManStudio()
+    protected function isRunningInBotManStudio(): bool
     {
         return class_exists(StudioServiceProvider::class);
     }

--- a/tests/Extensions/ReceiptTemplateTest.php
+++ b/tests/Extensions/ReceiptTemplateTest.php
@@ -142,9 +142,9 @@ class ReceiptTemplateTest extends PHPUnit_Framework_TestCase
     public function it_cant_add_a_summary()
     {
         $template = new ReceiptTemplate;
-        $template->addSummary(ReceiptSummary::create()->totalCost(99));
+        $template->addSummary(ReceiptSummary::create()->totalCost(99.00));
 
-        $this->assertSame(99, Arr::get($template->toArray(), 'attachment.payload.summary.total_cost'));
+        $this->assertSame(99., Arr::get($template->toArray(), 'attachment.payload.summary.total_cost'));
     }
 
     /**

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -40,7 +40,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
 
     private function getDriver($responseData, array $config = null, $signature = '', $htmlInterface = null)
     {
-        if (is_null($config)) {
+        if ($config === null) {
             $config = [
                 'facebook' => [
                     'token' => 'Foo',
@@ -139,7 +139,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
 
         $extras = $message->getExtras('nlp');
 
-        $this->assertFalse(is_null($extras));
+        $this->assertNotNull($extras);
         $this->assertSame('true', $extras['entities']['bye'][0]['value']);
     }
 


### PR DESCRIPTION
This PR do:

- add input/output type hinting for methods (as the minimum PHP version is set to 7.0 in composer.json)
- remove some duplicate code already present in parent or abstract class
- improve Docblock
- add small optimizations

**Warning**

If this PR is merged, the next release should be tag `2.0` as it bring I/O type hinting. By doing so, this will avoid BC break for people using version `< 2.0`