### PR TITLE
Add button text to conversation answer instead of button value for text field

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -236,7 +236,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     {
         $payload = $message->getPayload();
         if (isset($payload['message']['quick_reply'])) {
-            return Answer::create($message->getText())->setMessage($message)->setInteractiveReply(true)->setValue($payload['message']['quick_reply']['payload']);
+            return Answer::create($payload['message']['text'])->setMessage($message)->setInteractiveReply(true)->setValue($payload['message']['quick_reply']['payload']);
         } elseif (isset($payload['postback']['payload'])) {
             return Answer::create($payload['postback']['title'])->setMessage($message)->setInteractiveReply(true)->setValue($payload['postback']['payload']);
         }

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -1038,11 +1038,22 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $driver->markSeen($message);
     }
 
+    /** @test */
     public function it_returns_the_quick_reply_postback()
     {
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"quick_reply":{"payload":"MY_PAYLOAD"},"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Red"}}]}]}';
 
         $driver = $this->getDriver($request);
         $this->assertSame('MY_PAYLOAD', $driver->getMessages()[0]->getText());
+    }
+
+    /** @test */
+    public function it_returns_the_quick_reply_button_text_and_value_for_conversation_answer()
+    {
+        $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"quick_reply":{"payload":"MY_PAYLOAD"},"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Red"}}]}]}';
+
+        $driver = $this->getDriver($request);
+        $this->assertSame('Red', $driver->getConversationAnswer($driver->getMessages()[0])->getText());
+        $this->assertSame('MY_PAYLOAD', $driver->getConversationAnswer($driver->getMessages()[0])->getValue());
     }
 }


### PR DESCRIPTION
This PR changes what `getText` will return for a Quick Reply button. Before it returned the value of the button. Originally, It was intended that it returns the button text. This PR changes this to the original behavior.