### PR TITLE
Add input type hinting, remove duplicate code, improve Docblock, add some optimizations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "botman/botman": "~2.1|~3.0"
+        "botman/botman": "~2.1|~3.0",
+        "ext-json": "*"
     },
     "require-dev": {
         "botman/studio-addons": "~1.0",

--- a/src/Commands/AddGreetingText.php
+++ b/src/Commands/AddGreetingText.php
@@ -21,9 +21,7 @@ class AddGreetingText extends Command
      */
     protected $description = 'Add a Facebook Greeting Text to your message start screen.';
 
-    /**
-     * @var Curl
-     */
+    /** @var Curl */
     private $http;
 
     /**
@@ -57,10 +55,12 @@ class AddGreetingText extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Greeting text was set.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/AddPersistentMenu.php
+++ b/src/Commands/AddPersistentMenu.php
@@ -21,9 +21,7 @@ class AddPersistentMenu extends Command
      */
     protected $description = 'Add a persistent Facebook menu';
 
-    /**
-     * @var Curl
-     */
+    /** @var Curl */
     private $http;
 
     /**
@@ -56,10 +54,12 @@ class AddPersistentMenu extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Facebook menu was set.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/AddStartButtonPayload.php
+++ b/src/Commands/AddStartButtonPayload.php
@@ -21,9 +21,7 @@ class AddStartButtonPayload extends Command
      */
     protected $description = 'Add a Facebook Get Started button with a payload';
 
-    /**
-     * @var Curl
-     */
+    /** @var Curl */
     private $http;
 
     /**
@@ -63,10 +61,12 @@ class AddStartButtonPayload extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Get Started payload was set to: '.$payload);
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/Nlp.php
+++ b/src/Commands/Nlp.php
@@ -21,9 +21,7 @@ class Nlp extends Command
      */
     protected $description = 'Enable/Disable Facebooks built-in natural language processing';
 
-    /**
-     * @var Curl
-     */
+    /** @var Curl */
     private $http;
 
     /**
@@ -49,14 +47,16 @@ class Nlp extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             if ($this->option('disable')) {
                 $this->info('NLP was disabled.');
             } else {
                 $this->info('NLP was enabled.');
             }
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Commands/WhitelistDomains.php
+++ b/src/Commands/WhitelistDomains.php
@@ -21,9 +21,7 @@ class WhitelistDomains extends Command
      */
     protected $description = 'Whitelist domains';
 
-    /**
-     * @var Curl
-     */
+    /** @var Curl */
     private $http;
 
     /**
@@ -56,10 +54,12 @@ class WhitelistDomains extends Command
 
         $responseObject = json_decode($response->getContent());
 
-        if ($response->getStatusCode() == 200) {
+        if ($response->getStatusCode() === 200) {
             $this->info('Domains where whitelisted.');
-        } else {
-            $this->error('Something went wrong: '.$responseObject->error->message);
+
+            return;
         }
+
+        $this->error('Something went wrong: '.$responseObject->error->message);
     }
 }

--- a/src/Extensions/AbstractAirlineTemplate.php
+++ b/src/Extensions/AbstractAirlineTemplate.php
@@ -8,14 +8,10 @@ use BotMan\Drivers\Facebook\Interfaces\Airline;
 
 abstract class AbstractAirlineTemplate implements JsonSerializable, WebAccess, Airline
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $locale;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $themeColor;
 
     /**
@@ -33,7 +29,7 @@ abstract class AbstractAirlineTemplate implements JsonSerializable, WebAccess, A
      *
      * @return \BotMan\Drivers\Facebook\Extensions\AbstractAirlineTemplate
      */
-    public function themeColor(string $themeColor): self
+    public function themeColor(string $themeColor)
     {
         $this->themeColor = $themeColor;
 
@@ -43,7 +39,7 @@ abstract class AbstractAirlineTemplate implements JsonSerializable, WebAccess, A
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'attachment' => [
@@ -59,7 +55,7 @@ abstract class AbstractAirlineTemplate implements JsonSerializable, WebAccess, A
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -70,7 +66,7 @@ abstract class AbstractAirlineTemplate implements JsonSerializable, WebAccess, A
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         return [
             'locale' => $this->locale,

--- a/src/Extensions/Airline/AbstractAirlineFlightInfo.php
+++ b/src/Extensions/Airline/AbstractAirlineFlightInfo.php
@@ -7,24 +7,16 @@ use BotMan\Drivers\Facebook\Interfaces\Airline;
 
 abstract class AbstractAirlineFlightInfo implements JsonSerializable, Airline
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $flightNumber;
 
-    /**
-     * @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport
-     */
+    /** @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport */
     protected $departureAirport;
 
-    /**
-     * @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport
-     */
+    /** @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport */
     protected $arrivalAirport;
 
-    /**
-     * @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightSchedule
-     */
+    /** @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightSchedule */
     protected $flightSchedule;
 
     /**
@@ -50,7 +42,7 @@ abstract class AbstractAirlineFlightInfo implements JsonSerializable, Airline
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'flight_number' => $this->flightNumber,
@@ -63,7 +55,7 @@ abstract class AbstractAirlineFlightInfo implements JsonSerializable, Airline
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/Airline/AirlineAirport.php
+++ b/src/Extensions/Airline/AirlineAirport.php
@@ -6,24 +6,16 @@ use JsonSerializable;
 
 class AirlineAirport implements JsonSerializable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $airportCode;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $city;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $terminal;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $gate;
 
     /**
@@ -32,7 +24,7 @@ class AirlineAirport implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport
      */
-    public static function create(string $airportCode, string $city): self
+    public static function create(string $airportCode, string $city)
     {
         return new static($airportCode, $city);
     }
@@ -54,7 +46,7 @@ class AirlineAirport implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport
      */
-    public function terminal(string $terminal): self
+    public function terminal(string $terminal)
     {
         $this->terminal = $terminal;
 
@@ -66,7 +58,7 @@ class AirlineAirport implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineAirport
      */
-    public function gate(string $gate): self
+    public function gate(string $gate)
     {
         $this->gate = $gate;
 
@@ -76,7 +68,7 @@ class AirlineAirport implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = [
             'airport_code' => $this->airportCode,
@@ -91,7 +83,7 @@ class AirlineAirport implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/Airline/AirlineBoardingPass.php
+++ b/src/Extensions/Airline/AirlineBoardingPass.php
@@ -8,69 +8,43 @@ use BotMan\Drivers\Facebook\Exceptions\FacebookException;
 
 class AirlineBoardingPass implements JsonSerializable, Airline
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $passengerName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $pnrNumber;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $travelClass;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $seat;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $auxiliaryFields = [];
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $secondaryFields = [];
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $logoImageUrl;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $headerImageUrl;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $headerTextField;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $qrCode;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $barcodeImageUrl;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $aboveBarcodeImageUrl;
 
-    /**
-     * @var AirlineFlightInfo;
-     */
+    /** @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightInfo */
     protected $flightInfo;
 
     /**
@@ -90,7 +64,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
         string $code,
         string $aboveBarcodeImageUrl,
         AirlineFlightInfo $flightInfo
-    ): self {
+    ) {
         return new static($passengerName, $pnrNumber, $logoImageUrl, $code, $aboveBarcodeImageUrl, $flightInfo);
     }
 
@@ -128,7 +102,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function travelClass(string $travelClass): self
+    public function travelClass(string $travelClass)
     {
         if (! \in_array($travelClass, self::TRAVEL_TYPES, true)) {
             throw new FacebookException(
@@ -146,7 +120,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function seat(string $seat): self
+    public function seat(string $seat)
     {
         $this->seat = $seat;
 
@@ -159,7 +133,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function addAuxiliaryField(string $label, string $value): self
+    public function addAuxiliaryField(string $label, string $value)
     {
         $this->auxiliaryFields[] = $this->setLabelValue($label, $value);
 
@@ -171,7 +145,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function addAuxiliaryFields(array $auxiliaryFields): self
+    public function addAuxiliaryFields(array $auxiliaryFields)
     {
         foreach ($auxiliaryFields as $label => $value) {
             $this->auxiliaryFields[] = $this->setLabelValue($label, $value);
@@ -186,7 +160,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function addSecondaryField(string $label, string $value): self
+    public function addSecondaryField(string $label, string $value)
     {
         $this->secondaryFields[] = $this->setLabelValue($label, $value);
 
@@ -198,7 +172,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function addSecondaryFields(array $secondaryFields): self
+    public function addSecondaryFields(array $secondaryFields)
     {
         foreach ($secondaryFields as $label => $value) {
             $this->secondaryFields[] = $this->setLabelValue($label, $value);
@@ -212,7 +186,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function headerImageUrl(string $headerImageUrl): self
+    public function headerImageUrl(string $headerImageUrl)
     {
         $this->headerImageUrl = $headerImageUrl;
 
@@ -224,7 +198,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineBoardingPass
      */
-    public function headerTextField(string $headerTextField): self
+    public function headerTextField(string $headerTextField)
     {
         $this->headerTextField = $headerTextField;
 
@@ -250,7 +224,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
      *
      * @return array
      */
-    private function setLabelValue(string $label, string $value): array
+    private function setLabelValue(string $label, string $value)
     {
         return [
             'label' => $label,
@@ -261,7 +235,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = [
             'passenger_name' => $this->passengerName,
@@ -285,7 +259,7 @@ class AirlineBoardingPass implements JsonSerializable, Airline
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/Airline/AirlineExtendedFlightInfo.php
+++ b/src/Extensions/Airline/AirlineExtendedFlightInfo.php
@@ -6,24 +6,16 @@ use BotMan\Drivers\Facebook\Exceptions\FacebookException;
 
 class AirlineExtendedFlightInfo extends AbstractAirlineFlightInfo
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $connectionId;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $segmentId;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $aircraftType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $travelClass;
 
     /**
@@ -47,7 +39,7 @@ class AirlineExtendedFlightInfo extends AbstractAirlineFlightInfo
         AirlineAirport $arrivalAirport,
         AirlineFlightSchedule $flightSchedule,
         string $travelClass
-    ): self {
+    ) {
         return new static(
             $connectionId,
             $segmentId,
@@ -99,7 +91,7 @@ class AirlineExtendedFlightInfo extends AbstractAirlineFlightInfo
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineExtendedFlightInfo
      */
-    public function aircraftType(string $aircraftType): self
+    public function aircraftType(string $aircraftType)
     {
         $this->aircraftType = $aircraftType;
 
@@ -109,7 +101,7 @@ class AirlineExtendedFlightInfo extends AbstractAirlineFlightInfo
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = parent::toArray();
         $array += [

--- a/src/Extensions/Airline/AirlineFlightInfo.php
+++ b/src/Extensions/Airline/AirlineFlightInfo.php
@@ -17,7 +17,7 @@ class AirlineFlightInfo extends AbstractAirlineFlightInfo
         AirlineAirport $departureAirport,
         AirlineAirport $arrivalAirport,
         AirlineFlightSchedule $flightSchedule
-    ): self {
+    ) {
         return new self($flightNumber, $departureAirport, $arrivalAirport, $flightSchedule);
     }
 }

--- a/src/Extensions/Airline/AirlineFlightSchedule.php
+++ b/src/Extensions/Airline/AirlineFlightSchedule.php
@@ -6,19 +6,13 @@ use JsonSerializable;
 
 class AirlineFlightSchedule implements JsonSerializable
 {
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $boardingTime;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $departureTime;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $arrivalTime;
 
     /**
@@ -26,7 +20,7 @@ class AirlineFlightSchedule implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightSchedule
      */
-    public static function create(string $departureTime): self
+    public static function create(string $departureTime)
     {
         return new self($departureTime);
     }
@@ -46,7 +40,7 @@ class AirlineFlightSchedule implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightSchedule
      */
-    public function boardingTime(string $boardingTime): self
+    public function boardingTime(string $boardingTime)
     {
         $this->boardingTime = $boardingTime;
 
@@ -58,7 +52,7 @@ class AirlineFlightSchedule implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightSchedule
      */
-    public function arrivalTime(string $arrivalTime): self
+    public function arrivalTime(string $arrivalTime)
     {
         $this->arrivalTime = $arrivalTime;
 
@@ -68,7 +62,7 @@ class AirlineFlightSchedule implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = [
             'boarding_time' => $this->boardingTime,
@@ -82,7 +76,7 @@ class AirlineFlightSchedule implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/Airline/AirlinePassengerInfo.php
+++ b/src/Extensions/Airline/AirlinePassengerInfo.php
@@ -6,19 +6,13 @@ use JsonSerializable;
 
 class AirlinePassengerInfo implements JsonSerializable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $passengerId;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $ticketNumber;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name;
 
     /**
@@ -27,7 +21,7 @@ class AirlinePassengerInfo implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlinePassengerInfo
      */
-    public static function create(string $passengerId, string $name): self
+    public static function create(string $passengerId, string $name)
     {
         return new static($passengerId, $name);
     }
@@ -49,7 +43,7 @@ class AirlinePassengerInfo implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlinePassengerInfo
      */
-    public function ticketNumber(string $ticketNumber): self
+    public function ticketNumber(string $ticketNumber)
     {
         $this->ticketNumber = $ticketNumber;
 
@@ -59,7 +53,7 @@ class AirlinePassengerInfo implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = [
             'passenger_id' => $this->passengerId,
@@ -73,7 +67,7 @@ class AirlinePassengerInfo implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/Airline/AirlinePassengerSegmentInfo.php
+++ b/src/Extensions/Airline/AirlinePassengerSegmentInfo.php
@@ -6,29 +6,19 @@ use JsonSerializable;
 
 class AirlinePassengerSegmentInfo implements JsonSerializable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $segmentId;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $passengerId;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $seat;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $seatType;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $productInfo = [];
 
     /**
@@ -39,7 +29,7 @@ class AirlinePassengerSegmentInfo implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlinePassengerSegmentInfo
      */
-    public static function create(string $segmentId, string $passengerId, string $seat, string $seatType): self
+    public static function create(string $segmentId, string $passengerId, string $seat, string $seatType)
     {
         return new static($segmentId, $passengerId, $seat, $seatType);
     }
@@ -66,7 +56,7 @@ class AirlinePassengerSegmentInfo implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlinePassengerSegmentInfo
      */
-    public function addProductInfo(string $title, string $value): self
+    public function addProductInfo(string $title, string $value)
     {
         $this->productInfo[] = [
             'title' => $title,
@@ -81,7 +71,7 @@ class AirlinePassengerSegmentInfo implements JsonSerializable
      *
      * @return \BotMan\Drivers\Facebook\Extensions\Airline\AirlinePassengerSegmentInfo
      */
-    public function addProductsInfo(array $productsInfo): self
+    public function addProductsInfo(array $productsInfo)
     {
         foreach ($productsInfo as $title => $value) {
             $this->productInfo[] = [
@@ -96,7 +86,7 @@ class AirlinePassengerSegmentInfo implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = [
             'segment_id' => $this->segmentId,
@@ -112,7 +102,7 @@ class AirlinePassengerSegmentInfo implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/AirlineBoardingPassTemplate.php
+++ b/src/Extensions/AirlineBoardingPassTemplate.php
@@ -4,14 +4,10 @@ namespace BotMan\Drivers\Facebook\Extensions;
 
 class AirlineBoardingPassTemplate extends AbstractAirlineTemplate
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $introMessage;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $boardingPass;
 
     /**
@@ -42,7 +38,7 @@ class AirlineBoardingPassTemplate extends AbstractAirlineTemplate
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = parent::toArray();
 
@@ -63,7 +59,7 @@ class AirlineBoardingPassTemplate extends AbstractAirlineTemplate
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         $webDriver = parent::toWebDriver();
         $webDriver += [

--- a/src/Extensions/AirlineCheckInTemplate.php
+++ b/src/Extensions/AirlineCheckInTemplate.php
@@ -4,24 +4,16 @@ namespace BotMan\Drivers\Facebook\Extensions;
 
 class AirlineCheckInTemplate extends AbstractAirlineTemplate
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $introMessage;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $pnrNumber;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $flightInfo;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $checkinUrl;
 
     /**
@@ -70,7 +62,7 @@ class AirlineCheckInTemplate extends AbstractAirlineTemplate
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = parent::toArray();
 
@@ -93,7 +85,7 @@ class AirlineCheckInTemplate extends AbstractAirlineTemplate
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         $webDriver = parent::toWebDriver();
         $webDriver += [

--- a/src/Extensions/AirlineItineraryTemplate.php
+++ b/src/Extensions/AirlineItineraryTemplate.php
@@ -4,54 +4,34 @@ namespace BotMan\Drivers\Facebook\Extensions;
 
 class AirlineItineraryTemplate extends AbstractAirlineTemplate
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $introMessage;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $pnrNumber;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $passengerInfo;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $flightInfo;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $passengerSegmentInfo;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $priceInfo = [];
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $basePrice;
 
-    /**
-     * @var null|string
-     */
+    /** @var null|string */
     protected $tax;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $totalPrice;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $currency;
 
     /**
@@ -75,7 +55,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
         array $passengerSegmentInfo,
         string $totalPrice,
         string $currency
-    ): self {
+    ) {
         return new static(
             $introMessage,
             $locale,
@@ -128,7 +108,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
      *
      * @return \BotMan\Drivers\Facebook\Extensions\AirlineItineraryTemplate
      */
-    public function addPriceInfo(string $title, string $amount, string $currency = null): self
+    public function addPriceInfo(string $title, string $amount, string $currency = null)
     {
         $priceInfo = [
             'title' => $title,
@@ -146,7 +126,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
      *
      * @return \BotMan\Drivers\Facebook\Extensions\AirlineItineraryTemplate
      */
-    public function basePrice(string $basePrice): self
+    public function basePrice(string $basePrice)
     {
         $this->basePrice = $basePrice;
 
@@ -158,7 +138,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
      *
      * @return \BotMan\Drivers\Facebook\Extensions\AirlineItineraryTemplate
      */
-    public function tax(string $tax): self
+    public function tax(string $tax)
     {
         $this->tax = $tax;
 
@@ -168,7 +148,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = parent::toArray();
 
@@ -197,7 +177,7 @@ class AirlineItineraryTemplate extends AbstractAirlineTemplate
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         $webDriver = parent::toWebDriver();
         $webDriver += [

--- a/src/Extensions/AirlineUpdateTemplate.php
+++ b/src/Extensions/AirlineUpdateTemplate.php
@@ -7,24 +7,16 @@ use BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightInfo;
 
 class AirlineUpdateTemplate extends AbstractAirlineTemplate
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $introMessage;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $updateType;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $pnrNumber;
 
-    /**
-     * @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightInfo
-     */
+    /** @var \BotMan\Drivers\Facebook\Extensions\Airline\AirlineFlightInfo */
     protected $updateFlightInfo;
 
     /**
@@ -62,7 +54,7 @@ class AirlineUpdateTemplate extends AbstractAirlineTemplate
      *
      * @return \BotMan\Drivers\Facebook\Extensions\AirlineUpdateTemplate
      */
-    public function introMessage(string $introMessage): self
+    public function introMessage(string $introMessage)
     {
         $this->introMessage = $introMessage;
 
@@ -72,7 +64,7 @@ class AirlineUpdateTemplate extends AbstractAirlineTemplate
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         $array = parent::toArray();
 
@@ -95,7 +87,7 @@ class AirlineUpdateTemplate extends AbstractAirlineTemplate
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         $webDriver = parent::toWebDriver();
         $webDriver += [

--- a/src/Extensions/ButtonTemplate.php
+++ b/src/Extensions/ButtonTemplate.php
@@ -14,22 +14,29 @@ class ButtonTemplate implements JsonSerializable, WebAccess
     protected $buttons = [];
 
     /**
-     * @param $text
-     * @return static
+     * @param string $text
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
-    public static function create($text)
+    public static function create(string $text)
     {
         return new static($text);
     }
 
-    public function __construct($text)
+    /**
+     * ButtonTemplate constructor.
+     *
+     * @param string $text
+     */
+    public function __construct(string $text)
     {
         $this->text = $text;
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
     public function addButton(ElementButton $button)
     {
@@ -40,7 +47,8 @@ class ButtonTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ButtonTemplate
      */
     public function addButtons(array $buttons)
     {

--- a/src/Extensions/Element.php
+++ b/src/Extensions/Element.php
@@ -25,10 +25,11 @@ class Element implements JsonSerializable
     protected $default_action;
 
     /**
-     * @param $title
-     * @return static
+     * @param string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public static function create($title)
+    public static function create(string $title)
     {
         return new static($title);
     }
@@ -36,16 +37,17 @@ class Element implements JsonSerializable
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
 
     /**
      * @param string $title
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function title($title)
+    public function title(string $title)
     {
         $this->title = $title;
 
@@ -54,9 +56,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $subtitle
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function subtitle($subtitle)
+    public function subtitle(string $subtitle)
     {
         $this->subtitle = $subtitle;
 
@@ -65,9 +68,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $image_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
-    public function image($image_url)
+    public function image(string $image_url)
     {
         $this->image_url = $image_url;
 
@@ -76,9 +80,10 @@ class Element implements JsonSerializable
 
     /**
      * @param string $item_url
+     *
      * @return $this
      */
-    public function itemUrl($item_url)
+    public function itemUrl(string $item_url)
     {
         $this->item_url = $item_url;
 
@@ -86,8 +91,9 @@ class Element implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
     public function addButton(ElementButton $button)
     {
@@ -98,15 +104,14 @@ class Element implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
     public function addButtons(array $buttons)
     {
-        if (isset($buttons) && is_array($buttons)) {
-            foreach ($buttons as $button) {
-                if ($button instanceof ElementButton) {
-                    $this->buttons[] = $button->toArray();
-                }
+        foreach ($buttons as $button) {
+            if ($button instanceof ElementButton) {
+                $this->buttons[] = $button->toArray();
             }
         }
 
@@ -114,9 +119,9 @@ class Element implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $defaultAction
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $defaultAction
      *
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\Element
      */
     public function defaultAction(ElementButton $defaultAction)
     {

--- a/src/Extensions/ElementButton.php
+++ b/src/Extensions/ElementButton.php
@@ -4,6 +4,18 @@ namespace BotMan\Drivers\Facebook\Extensions;
 
 class ElementButton
 {
+    const TYPE_ACCOUNT_LINK = 'account_link';
+    const TYPE_ACCOUNT_UNLINK = 'account_unlink';
+    const TYPE_WEB_URL = 'web_url';
+    const TYPE_PAYMENT = 'payment';
+    const TYPE_POSTBACK = 'postback';
+    const TYPE_SHARE = 'element_share';
+    const TYPE_CALL = 'phone_number';
+
+    const RATIO_COMPACT = 'compact';
+    const RATIO_TALL = 'tall';
+    const RATIO_FULL = 'full';
+
     /** @var string */
     protected $title;
 
@@ -31,41 +43,32 @@ class ElementButton
     /** @var GenericTemplate */
     protected $shareContents;
 
-    const TYPE_ACCOUNT_LINK = 'account_link';
-    const TYPE_ACCOUNT_UNLINK = 'account_unlink';
-    const TYPE_WEB_URL = 'web_url';
-    const TYPE_PAYMENT = 'payment';
-    const TYPE_POSTBACK = 'postback';
-    const TYPE_SHARE = 'element_share';
-    const TYPE_CALL = 'phone_number';
-
-    const RATIO_COMPACT = 'compact';
-    const RATIO_TALL = 'tall';
-    const RATIO_FULL = 'full';
-
     /**
-     * @param string $title
-     * @return static
+     * @param null|string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public static function create($title)
+    public static function create($title = null)
     {
         return new static($title);
     }
 
     /**
-     * @param string $title
+     * @param null|string $title
      */
-    public function __construct($title)
+    public function __construct($title = null)
     {
         $this->title = $title;
     }
 
     /**
      * Set the button URL.
+     *
      * @param string $url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function url($url)
+    public function url(string $url)
     {
         $this->url = $url;
 
@@ -74,10 +77,12 @@ class ElementButton
 
     /**
      * Set the button type.
+     *
      * @param string $type
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function type($type)
+    public function type(string $type)
     {
         $this->type = $type;
 
@@ -85,10 +90,11 @@ class ElementButton
     }
 
     /**
-     * @param $payload
-     * @return $this
+     * @param string $payload
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function payload($payload)
+    public function payload(string $payload)
     {
         $this->payload = $payload;
 
@@ -97,9 +103,10 @@ class ElementButton
 
     /**
      * @param string $fallback_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function fallbackUrl($fallback_url)
+    public function fallbackUrl(string $fallback_url)
     {
         $this->fallback_url = $fallback_url;
 
@@ -108,7 +115,8 @@ class ElementButton
 
     /**
      * enable messenger extensions.
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
     public function enableExtensions()
     {
@@ -118,7 +126,7 @@ class ElementButton
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
     public function disableShare()
     {
@@ -128,7 +136,7 @@ class ElementButton
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
     public function removeHeightRatio()
     {
@@ -139,10 +147,12 @@ class ElementButton
 
     /**
      * Set ratio to one of RATIO_COMPACT, RATIO_TALL, RATIO_FULL.
+     *
      * @param string $ratio
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function heightRatio($ratio = self::RATIO_FULL)
+    public function heightRatio(string $ratio = self::RATIO_FULL)
     {
         $this->webview_height_ratio = $ratio;
 
@@ -153,10 +163,12 @@ class ElementButton
      * Optional. The message that you wish the recipient of the share to see,
      * if it is different from the one this button is attached to.
      * The format follows that used in Send API, but must be a generic template with up to one URL button.
+     *
      * @param GenericTemplate $shareContents
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ElementButton
      */
-    public function shareContents($shareContents)
+    public function shareContents(GenericTemplate $shareContents)
     {
         $this->shareContents = $shareContents;
 
@@ -184,10 +196,10 @@ class ElementButton
             }
 
             if ($this->type === self::TYPE_WEB_URL) {
-                if (! is_null($this->webview_height_ratio)) {
+                if ($this->webview_height_ratio !== null) {
                     $buttonArray['webview_height_ratio'] = $this->webview_height_ratio;
                 }
-                if (! is_null($this->webview_share_button)) {
+                if ($this->webview_share_button !== null) {
                     $buttonArray['webview_share_button'] = $this->webview_share_button;
                 }
 
@@ -196,7 +208,7 @@ class ElementButton
                     $buttonArray['fallback_url'] = $this->fallback_url ?: $this->url;
                 }
             }
-        } elseif ($this->type == self::TYPE_SHARE && ! is_null($this->shareContents)) {
+        } elseif ($this->type === self::TYPE_SHARE && $this->shareContents !== null) {
             $buttonArray['share_contents'] = $this->shareContents->toArray();
         }
 

--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -23,7 +23,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
     protected $imageAspectRatio = self::RATIO_HORIZONTAL;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
     public static function create()
     {
@@ -31,8 +31,9 @@ class GenericTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param Element $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\Element $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
     public function addElement(Element $element)
     {
@@ -43,7 +44,8 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
     public function addElements(array $elements)
     {
@@ -58,11 +60,12 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param string $ratio
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\GenericTemplate
      */
-    public function addImageAspectRatio($ratio)
+    public function addImageAspectRatio(string $ratio)
     {
-        if (in_array($ratio, self::$allowedRatios)) {
+        if (\ in_array($ratio, self::$allowedRatios, true)) {
             $this->imageAspectRatio = $ratio;
         }
 

--- a/src/Extensions/ListTemplate.php
+++ b/src/Extensions/ListTemplate.php
@@ -17,7 +17,7 @@ class ListTemplate implements JsonSerializable, WebAccess
     protected $top_element_style = 'large';
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
     public static function create()
     {
@@ -25,8 +25,9 @@ class ListTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param Element $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\Element $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
     public function addElement(Element $element)
     {
@@ -37,7 +38,8 @@ class ListTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
     public function addElements(array $elements)
     {
@@ -51,8 +53,9 @@ class ListTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
     public function addGlobalButton(ElementButton $button)
     {
@@ -62,7 +65,7 @@ class ListTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @return $this
+     * @return \BotMan\Drivers\Facebook\Extensions\ListTemplate
      */
     public function useCompactView()
     {

--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -16,27 +16,31 @@ class MediaAttachmentElement implements JsonSerializable
     protected $buttons;
 
     /**
-     * @param $mediaType
-     * @return static
+     * @param string $mediaType
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public static function create($mediaType)
+    public static function create(string $mediaType)
     {
         return new static($mediaType);
     }
 
     /**
-     * @param $mediaType
+     * MediaAttachmentElement constructor.
+     *
+     * @param string $mediaType
      */
-    public function __construct($mediaType)
+    public function __construct(string $mediaType)
     {
         $this->media_type = $mediaType;
     }
 
     /**
-     * @param $attachmentId
-     * @return $this
+     * @param string $attachmentId
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
-    public function attachmentId($attachmentId)
+    public function attachmentId(string $attachmentId)
     {
         $this->attachment_id = $attachmentId;
 
@@ -44,8 +48,9 @@ class MediaAttachmentElement implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
     public function addButton(ElementButton $button)
     {
@@ -56,7 +61,8 @@ class MediaAttachmentElement implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaAttachmentElement
      */
     public function addButtons(array $buttons)
     {

--- a/src/Extensions/MediaTemplate.php
+++ b/src/Extensions/MediaTemplate.php
@@ -14,7 +14,7 @@ class MediaTemplate implements JsonSerializable, WebAccess
     protected $elements = [];
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaTemplate
      */
     public static function create()
     {
@@ -23,11 +23,12 @@ class MediaTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $element
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaTemplate
      */
     public function element($element)
     {
-        $this->elements = [$element->toArray()];
+        $this->elements[] = $element->toArray();
 
         return $this;
     }

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -16,27 +16,31 @@ class MediaUrlElement implements JsonSerializable
     protected $buttons;
 
     /**
-     * @param $mediaType
-     * @return static
+     * @param string $mediaType
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public static function create($mediaType)
+    public static function create(string $mediaType)
     {
         return new static($mediaType);
     }
 
     /**
-     * @param $mediaType
+     * MediaUrlElement constructor.
+     *
+     * @param string $mediaType
      */
-    public function __construct($mediaType)
+    public function __construct(string $mediaType)
     {
         $this->media_type = $mediaType;
     }
 
     /**
-     * @param $url
-     * @return $this
+     * @param string $url
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
-    public function url($url)
+    public function url(string $url)
     {
         $this->url = $url;
 
@@ -44,8 +48,9 @@ class MediaUrlElement implements JsonSerializable
     }
 
     /**
-     * @param ElementButton $button
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ElementButton $button
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
     public function addButton(ElementButton $button)
     {
@@ -56,7 +61,8 @@ class MediaUrlElement implements JsonSerializable
 
     /**
      * @param array $buttons
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\MediaUrlElement
      */
     public function addButtons(array $buttons)
     {

--- a/src/Extensions/OpenGraphElement.php
+++ b/src/Extensions/OpenGraphElement.php
@@ -6,14 +6,10 @@ use JsonSerializable;
 
 class OpenGraphElement implements JsonSerializable
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $url;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $buttons;
 
     /**
@@ -29,7 +25,7 @@ class OpenGraphElement implements JsonSerializable
      *
      * @return $this
      */
-    public function url(string $url): self
+    public function url(string $url)
     {
         $this->url = $url;
 
@@ -41,7 +37,7 @@ class OpenGraphElement implements JsonSerializable
      *
      * @return $this
      */
-    public function addButton(ElementButton $button): self
+    public function addButton(ElementButton $button)
     {
         $this->buttons[] = $button->toArray();
 
@@ -53,7 +49,7 @@ class OpenGraphElement implements JsonSerializable
      *
      * @return $this
      */
-    public function addButtons(array $buttons): self
+    public function addButtons(array $buttons)
     {
         foreach ($buttons as $button) {
             if ($button instanceof ElementButton) {
@@ -67,7 +63,7 @@ class OpenGraphElement implements JsonSerializable
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'url' => $this->url,
@@ -78,7 +74,7 @@ class OpenGraphElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }

--- a/src/Extensions/OpenGraphTemplate.php
+++ b/src/Extensions/OpenGraphTemplate.php
@@ -7,14 +7,10 @@ use BotMan\BotMan\Interfaces\WebAccess;
 
 class OpenGraphTemplate implements JsonSerializable, WebAccess
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $mediaType;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $elements = [];
 
     /**
@@ -30,7 +26,7 @@ class OpenGraphTemplate implements JsonSerializable, WebAccess
      *
      * @return $this
      */
-    public function addElement(OpenGraphElement $element): self
+    public function addElement(OpenGraphElement $element)
     {
         $this->elements[] = $element->toArray();
 
@@ -42,7 +38,7 @@ class OpenGraphTemplate implements JsonSerializable, WebAccess
      *
      * @return $this
      */
-    public function addElements(array $elements): self
+    public function addElements(array $elements)
     {
         foreach ($elements as $element) {
             if ($element instanceof OpenGraphElement) {
@@ -56,7 +52,7 @@ class OpenGraphTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'attachment' => [
@@ -72,7 +68,7 @@ class OpenGraphTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize()
     {
         return $this->toArray();
     }
@@ -83,7 +79,7 @@ class OpenGraphTemplate implements JsonSerializable, WebAccess
      *
      * @return array
      */
-    public function toWebDriver(): array
+    public function toWebDriver()
     {
         return [
             'type' => $this->mediaType,

--- a/src/Extensions/QuickReplyButton.php
+++ b/src/Extensions/QuickReplyButton.php
@@ -6,6 +6,8 @@ use BotMan\BotMan\Interfaces\QuestionActionInterface;
 
 class QuickReplyButton implements QuestionActionInterface
 {
+    const TYPE_TEXT = 'text';
+
     /** @var string */
     protected $contentType = self::TYPE_TEXT;
 
@@ -18,13 +20,12 @@ class QuickReplyButton implements QuestionActionInterface
     /** @var string */
     protected $imageUrl;
 
-    const TYPE_TEXT = 'text';
-
     /**
      * @param string $title
-     * @return static
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public static function create($title = '')
+    public static function create(string $title = '')
     {
         return new static($title);
     }
@@ -32,7 +33,7 @@ class QuickReplyButton implements QuestionActionInterface
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
@@ -41,9 +42,10 @@ class QuickReplyButton implements QuestionActionInterface
      * Set the button type.
      *
      * @param string $type
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function type($type)
+    public function type(string $type)
     {
         $this->contentType = $type;
 
@@ -51,10 +53,11 @@ class QuickReplyButton implements QuestionActionInterface
     }
 
     /**
-     * @param $payload
-     * @return $this
+     * @param string $payload
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function payload($payload)
+    public function payload(string $payload)
     {
         $this->payload = $payload;
 
@@ -62,12 +65,11 @@ class QuickReplyButton implements QuestionActionInterface
     }
 
     /**
-     * Set the button URL.
-     *
      * @param string $url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\QuickReplyButton
      */
-    public function imageUrl($url)
+    public function imageUrl(string $url)
     {
         $this->imageUrl = $url;
 
@@ -81,7 +83,7 @@ class QuickReplyButton implements QuestionActionInterface
     {
         $buttonArray = [];
 
-        if ($this->contentType === 'text') {
+        if ($this->contentType === self::TYPE_TEXT) {
             $buttonArray = [
                 'content_type' => $this->contentType,
                 'title' => $this->title,

--- a/src/Extensions/ReceiptAddress.php
+++ b/src/Extensions/ReceiptAddress.php
@@ -25,7 +25,7 @@ class ReceiptAddress implements JsonSerializable
     protected $country;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
     public static function create()
     {
@@ -34,9 +34,10 @@ class ReceiptAddress implements JsonSerializable
 
     /**
      * @param string $street
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function street1($street)
+    public function street1(string $street)
     {
         $this->street_1 = $street;
 
@@ -45,9 +46,10 @@ class ReceiptAddress implements JsonSerializable
 
     /**
      * @param string $street
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function street2($street)
+    public function street2(string $street)
     {
         $this->street_2 = $street;
 
@@ -55,10 +57,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $city
-     * @return $this
+     * @param string $city
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function city($city)
+    public function city(string $city)
     {
         $this->city = $city;
 
@@ -66,10 +69,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $postalCode
-     * @return $this
+     * @param string $postalCode
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function postalCode($postalCode)
+    public function postalCode(string $postalCode)
     {
         $this->postal_code = $postalCode;
 
@@ -77,10 +81,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param $state
-     * @return $this
+     * @param string $state
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAddress
      */
-    public function state($state)
+    public function state(string $state)
     {
         $this->state = $state;
 
@@ -88,10 +93,11 @@ class ReceiptAddress implements JsonSerializable
     }
 
     /**
-     * @param string $country
+     * @param $country
+     *
      * @return $this
      */
-    public function country($country)
+    public function country(string $country)
     {
         $this->country = $country;
 

--- a/src/Extensions/ReceiptAdjustment.php
+++ b/src/Extensions/ReceiptAdjustment.php
@@ -13,28 +13,31 @@ class ReceiptAdjustment implements JsonSerializable
     protected $amount;
 
     /**
-     * @param $name
-     * @return static
+     * @param string $name
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment
      */
-    public static function create($name)
+    public static function create(string $name)
     {
         return new static($name);
     }
 
     /**
      * ReceiptAdjustment constructor.
-     * @param $name
+     *
+     * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
 
     /**
-     * @param string $amount
-     * @return $this
+     * @param float $amount
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment
      */
-    public function amount($amount)
+    public function amount(float $amount)
     {
         $this->amount = $amount;
 

--- a/src/Extensions/ReceiptElement.php
+++ b/src/Extensions/ReceiptElement.php
@@ -25,10 +25,11 @@ class ReceiptElement implements JsonSerializable
     protected $image_url;
 
     /**
-     * @param $title
-     * @return static
+     * @param string $title
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public static function create($title)
+    public static function create(string $title)
     {
         return new static($title);
     }
@@ -36,16 +37,17 @@ class ReceiptElement implements JsonSerializable
     /**
      * @param string $title
      */
-    public function __construct($title)
+    public function __construct(string $title)
     {
         $this->title = $title;
     }
 
     /**
      * @param string $subtitle
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function subtitle($subtitle)
+    public function subtitle(string $subtitle)
     {
         $this->subtitle = $subtitle;
 
@@ -53,10 +55,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $quantity
-     * @return $this
+     * @param int $quantity
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function quantity($quantity)
+    public function quantity(int $quantity)
     {
         $this->quantity = $quantity;
 
@@ -64,10 +67,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $price
-     * @return $this
+     * @param float $price
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function price($price)
+    public function price(float $price)
     {
         $this->price = $price;
 
@@ -75,10 +79,11 @@ class ReceiptElement implements JsonSerializable
     }
 
     /**
-     * @param $currency
-     * @return $this
+     * @param string $currency
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function currency($currency)
+    public function currency(string $currency)
     {
         $this->currency = $currency;
 
@@ -87,9 +92,10 @@ class ReceiptElement implements JsonSerializable
 
     /**
      * @param string $image_url
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptElement
      */
-    public function image($image_url)
+    public function image(string $image_url)
     {
         $this->image_url = $image_url;
 

--- a/src/Extensions/ReceiptSummary.php
+++ b/src/Extensions/ReceiptSummary.php
@@ -19,7 +19,7 @@ class ReceiptSummary implements JsonSerializable
     protected $total_cost;
 
     /**
-     * @return static
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
     public static function create()
     {
@@ -27,10 +27,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param string $subtotal
-     * @return $this
+     * @param float $subtotal
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function subtotal($subtotal)
+    public function subtotal(float $subtotal)
     {
         $this->subtotal = $subtotal;
 
@@ -38,10 +39,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param string $shippingCost
-     * @return $this
+     * @param float $shippingCost
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function shippingCost($shippingCost)
+    public function shippingCost(float $shippingCost)
     {
         $this->shipping_cost = $shippingCost;
 
@@ -49,10 +51,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param $totalTax
-     * @return $this
+     * @param float $totalTax
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function totalTax($totalTax)
+    public function totalTax(float $totalTax)
     {
         $this->total_tax = $totalTax;
 
@@ -60,10 +63,11 @@ class ReceiptSummary implements JsonSerializable
     }
 
     /**
-     * @param $totalCost
-     * @return $this
+     * @param float $totalCost
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptSummary
      */
-    public function totalCost($totalCost)
+    public function totalCost(float $totalCost)
     {
         $this->total_cost = $totalCost;
 

--- a/src/Extensions/ReceiptTemplate.php
+++ b/src/Extensions/ReceiptTemplate.php
@@ -50,9 +50,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $name
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function recipientName($name)
+    public function recipientName(string $name)
     {
         $this->recipient_name = $name;
 
@@ -61,9 +62,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $name
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function merchantName($name)
+    public function merchantName(string $name)
     {
         $this->merchant_name = $name;
 
@@ -72,9 +74,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $orderNumber
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function orderNumber($orderNumber)
+    public function orderNumber(string $orderNumber)
     {
         $this->order_number = $orderNumber;
 
@@ -83,9 +86,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $currency
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function currency($currency)
+    public function currency(string $currency)
     {
         $this->currency = $currency;
 
@@ -94,9 +98,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $paymentMethod
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function paymentMethod($paymentMethod)
+    public function paymentMethod(string $paymentMethod)
     {
         $this->payment_method = $paymentMethod;
 
@@ -105,9 +110,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $orderUrl
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function orderUrl($orderUrl)
+    public function orderUrl(string $orderUrl)
     {
         $this->order_url = $orderUrl;
 
@@ -116,9 +122,10 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param $timestamp
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
-    public function timestamp($timestamp)
+    public function timestamp(string $timestamp)
     {
         $this->timestamp = $timestamp;
 
@@ -126,8 +133,9 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptElement $element
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptElement $element
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
     public function addElement(ReceiptElement $element)
     {
@@ -138,7 +146,8 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $elements
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
     public function addElements(array $elements)
     {
@@ -152,8 +161,9 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptAddress $address
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptAddress $address
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
     public function addAddress(ReceiptAddress $address)
     {
@@ -163,8 +173,9 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptSummary $summary
-     * @return $this
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptSummary $summary
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
     public function addSummary(ReceiptSummary $summary)
     {
@@ -174,7 +185,8 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     }
 
     /**
-     * @param ReceiptAdjustment $adjustment
+     * @param \BotMan\Drivers\Facebook\Extensions\ReceiptAdjustment $adjustment
+     *
      * @return $this
      */
     public function addAdjustment(ReceiptAdjustment $adjustment)
@@ -186,7 +198,8 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
 
     /**
      * @param array $adjustments
-     * @return $this
+     *
+     * @return \BotMan\Drivers\Facebook\Extensions\ReceiptTemplate
      */
     public function addAdjustments(array $adjustments)
     {

--- a/src/Extensions/User.php
+++ b/src/Extensions/User.php
@@ -2,32 +2,12 @@
 
 namespace BotMan\Drivers\Facebook\Extensions;
 
-use BotMan\BotMan\Interfaces\UserInterface;
 use BotMan\BotMan\Users\User as BotManUser;
 
-class User extends BotManUser implements UserInterface
+class User extends BotManUser
 {
     /**
-     * @var array
-     */
-    protected $user_info;
-
-    public function __construct(
-        $id = null,
-        $first_name = null,
-        $last_name = null,
-        $username = null,
-        array $user_info = []
-    ) {
-        $this->id = $id;
-        $this->first_name = $first_name;
-        $this->last_name = $last_name;
-        $this->username = $username;
-        $this->user_info = (array) $user_info;
-    }
-
-    /**
-     * @return string
+     * @return string|null
      */
     public function getProfilePic()
     {
@@ -42,7 +22,7 @@ class User extends BotManUser implements UserInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLocale()
     {
@@ -50,34 +30,34 @@ class User extends BotManUser implements UserInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     public function getTimezone()
     {
-        return isset($this->user_info['timezone']) ? $this->user_info['timezone'] : null;
+        return $this->user_info['timezone'] ?? null;
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getGender()
     {
-        return isset($this->user_info['gender']) ? $this->user_info['gender'] : null;
+        return $this->user_info['gender'] ?? null;
     }
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getIsPaymentEnabled()
     {
-        return isset($this->user_info['is_payment_enabled']) ? $this->user_info['is_payment_enabled'] : null;
+        return $this->user_info['is_payment_enabled'] ?? null;
     }
 
     /**
-     * @return array
+     * @return array|null
      */
     public function getLastAdReferral()
     {
-        return isset($this->user_info['last_ad_referral']) ? $this->user_info['last_ad_referral'] : null;
+        return $this->user_info['last_ad_referral'] ?? null;
     }
 }

--- a/src/FacebookAudioDriver.php
+++ b/src/FacebookAudioDriver.php
@@ -19,9 +19,9 @@ class FacebookAudioDriver extends FacebookDriver
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'audio';
+                    return isset($attachment['type']) && $attachment['type'] === 'audio';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookAudioDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Audio::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setAudio($this->getAudioUrls($msg));
@@ -59,7 +45,7 @@ class FacebookAudioDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,6 +56,7 @@ class FacebookAudioDriver extends FacebookDriver
      * Retrieve audio file urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the audio file.
      */
     public function getAudioUrls(array $message)

--- a/src/FacebookFileDriver.php
+++ b/src/FacebookFileDriver.php
@@ -19,9 +19,9 @@ class FacebookFileDriver extends FacebookDriver
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'file';
+                    return isset($attachment['type']) && $attachment['type'] === 'file';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookFileDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(File::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setFiles($this->getFiles($msg));
@@ -59,7 +45,7 @@ class FacebookFileDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,6 +56,7 @@ class FacebookFileDriver extends FacebookDriver
      * Retrieve file urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the file.
      */
     public function getFiles(array $message)

--- a/src/FacebookImageDriver.php
+++ b/src/FacebookImageDriver.php
@@ -19,9 +19,9 @@ class FacebookImageDriver extends FacebookDriver
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'image';
+                    return isset($attachment['type']) && $attachment['type'] === 'image';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookImageDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Image::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setImages($this->getImagesUrls($msg));
@@ -59,7 +45,7 @@ class FacebookImageDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,6 +56,7 @@ class FacebookImageDriver extends FacebookDriver
      * Retrieve image urls from an incoming message.
      *
      * @param array $message
+     *
      * @return array A download for the image file.
      */
     public function getImagesUrls(array $message)

--- a/src/FacebookLocationDriver.php
+++ b/src/FacebookLocationDriver.php
@@ -19,9 +19,9 @@ class FacebookLocationDriver extends FacebookDriver
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'location';
+                    return isset($attachment['type']) && $attachment['type'] === 'location';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookLocationDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Location::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setLocation($this->getLocation($msg));
@@ -59,7 +45,7 @@ class FacebookLocationDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 
@@ -70,6 +56,7 @@ class FacebookLocationDriver extends FacebookDriver
      * Retrieve location from an incoming message.
      *
      * @param array $messages
+     *
      * @return \BotMan\BotMan\Messages\Attachments\Location
      */
     public function getLocation(array $messages)

--- a/src/FacebookVideoDriver.php
+++ b/src/FacebookVideoDriver.php
@@ -19,9 +19,9 @@ class FacebookVideoDriver extends FacebookDriver
     {
         $validSignature = ! $this->config->has('facebook_app_secret') || $this->validateSignature();
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            if (isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments'])) {
+            if (isset($msg['message']['attachments'])) {
                 return Collection::make($msg['message']['attachments'])->filter(function ($attachment) {
-                    return (isset($attachment['type'])) && $attachment['type'] === 'video';
+                    return isset($attachment['type']) && $attachment['type'] === 'video';
                 })->isEmpty() === false;
             }
 
@@ -32,26 +32,12 @@ class FacebookVideoDriver extends FacebookDriver
     }
 
     /**
-     * Retrieve the chat message.
-     *
-     * @return array
-     */
-    public function getMessages()
-    {
-        if (empty($this->messages)) {
-            $this->loadMessages();
-        }
-
-        return $this->messages;
-    }
-
-    /**
      * Load Facebook messages.
      */
     protected function loadMessages()
     {
         $messages = Collection::make($this->event->get('messaging'))->filter(function ($msg) {
-            return isset($msg['message']) && isset($msg['message']['attachments']) && isset($msg['message']['attachments']);
+            return isset($msg['message']['attachments']);
         })->transform(function ($msg) {
             $message = new IncomingMessage(Video::PATTERN, $msg['sender']['id'], $msg['recipient']['id'], $msg);
             $message->setVideos($this->getVideoUrls($msg));
@@ -59,7 +45,7 @@ class FacebookVideoDriver extends FacebookDriver
             return $message;
         })->toArray();
 
-        if (count($messages) === 0) {
+        if (\count($messages) === 0) {
             $messages = [new IncomingMessage('', '', '')];
         }
 

--- a/tests/Extensions/ReceiptTemplateTest.php
+++ b/tests/Extensions/ReceiptTemplateTest.php
@@ -142,9 +142,9 @@ class ReceiptTemplateTest extends PHPUnit_Framework_TestCase
     public function it_cant_add_a_summary()
     {
         $template = new ReceiptTemplate;
-        $template->addSummary(ReceiptSummary::create()->totalCost(99));
+        $template->addSummary(ReceiptSummary::create()->totalCost(99.00));
 
-        $this->assertSame(99, Arr::get($template->toArray(), 'attachment.payload.summary.total_cost'));
+        $this->assertSame(99., Arr::get($template->toArray(), 'attachment.payload.summary.total_cost'));
     }
 
     /**

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -40,7 +40,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
 
     private function getDriver($responseData, array $config = null, $signature = '', $htmlInterface = null)
     {
-        if (is_null($config)) {
+        if ($config === null) {
             $config = [
                 'facebook' => [
                     'token' => 'Foo',
@@ -139,7 +139,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
 
         $extras = $message->getExtras('nlp');
 
-        $this->assertFalse(is_null($extras));
+        $this->assertNotNull($extras);
         $this->assertSame('true', $extras['entities']['bye'][0]['value']);
     }
 


### PR DESCRIPTION
This PR do:

* add input type hinting for methods (as the minimum PHP version is set to 7.0 in composer.json)
* remove some duplicate code already present in parent or abstract class
* improve Docblock
* add small optimizations

**Warning**

If this PR is merged, the next release should be tag 2.0 as it bring I/O type hinting. By doing so, this will avoid BC break for people using version < 2.0