### PR TITLE
Adding a QuickReplyTemplate

### DIFF
--- a/src/Extensions/QuickReplyTemplate.php
+++ b/src/Extensions/QuickReplyTemplate.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: obeone
+ * Date: 2018-12-13
+ * Time: 16:58
+ */
+
+namespace BotMan\Drivers\Facebook\Extensions;
+
+
+class QuickReplyTemplate
+{
+    /** @var string  */
+    protected $title;
+
+    /** @var mixed  */
+    protected $attachment;
+
+    /** @var array */
+    protected $actions;
+
+    /**
+     * @param string $title
+     *
+     * @return QuickReplyTemplate
+     */
+    public static function create($title = '')
+    {
+        return new static($title);
+    }
+
+
+    /**
+     * QuickReply constructor.
+     *
+     * @param $title
+     */
+    public function __construct($title)
+    {
+        if (is_string($title)) {
+            $this->title = $title;
+        } else {
+            $this->attachment = $title;
+        }
+
+        $this->actions = [];
+    }
+
+
+    /**
+     * @param QuestionActionInterface $action
+     *
+     * @return $this
+     */
+    public function addAction(QuestionActionInterface $action)
+    {
+        $this->actions[] = $action->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param \BotMan\BotMan\Messages\Outgoing\Actions\Button $button
+     * @return $this
+     */
+    public function addButton(QuickReplyButton $button)
+    {
+        $this->actions[] = $button->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param array $buttons
+     * @return $this
+     */
+    public function addButtons(array $buttons)
+    {
+        foreach ($buttons as $button) {
+            $this->actions[] = $button->toArray();
+        }
+
+        return $this;
+    }
+
+    public function toArray()
+    {
+        $ret = [];
+        if (!is_null($this->title)) {
+            $ret['text'] = $this->title;
+        } else {
+            $ret = $this->attachment->toArray();
+        }
+
+        $ret['quick_replies'] = $this->actions;
+
+        return $ret;
+    }
+}

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\Drivers\Facebook;
 
+use BotMan\Drivers\Facebook\Extensions\QuickReplyTemplate;
 use Illuminate\Support\Collection;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Messages\Incoming\Answer;
@@ -64,6 +65,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         ReceiptTemplate::class,
         MediaTemplate::class,
         OpenGraphTemplate::class,
+        QuickReplyTemplate::class,
     ];
 
     private $supportedAttachments = [


### PR DESCRIPTION
Hi,

It's possible to set quick replies buttons to a lot of type template according to the messenger documentation : https://developers.facebook.com/docs/messenger-platform/send-messages/quick-replies

I created a quick and dirty template which can embed another template and quick replies buttons. I think there might be better way to do that, and I didn't write unit test but I'm really hurry on a project :/