### PR TITLE
This PR adds sharable property on Generic Template

### DIFF
--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -70,6 +70,16 @@ class GenericTemplate implements JsonSerializable, WebAccess
     }
 
     /**
+     * @param string $ratio
+     * @return $this
+     */
+    public function addSharable($sharable)
+    {
+        $this->sharable = $sharable;
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()
@@ -79,6 +89,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
                 'type' => 'template',
                 'payload' => [
                     'template_type' => 'generic',
+                    'sharable' => $this->sharable,
                     'image_aspect_ratio' => $this->imageAspectRatio,
                     'elements' => $this->elements,
                 ],


### PR DESCRIPTION
FB documentation suggests that this property defaults to false.  This PR adds the property using the existing naming convention using the addSharable() method to the Facebook Driver extension.