### PR TITLE
generic template add quick reply button

### DIFF
--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -2,8 +2,8 @@
 
 namespace BotMan\Drivers\Facebook\Extensions;
 
-use JsonSerializable;
 use BotMan\BotMan\Interfaces\WebAccess;
+use JsonSerializable;
 
 class GenericTemplate implements JsonSerializable, WebAccess
 {
@@ -18,6 +18,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /** @var array */
     protected $elements = [];
+    protected $quick_replies = [];
 
     /** @var string */
     protected $imageAspectRatio = self::RATIO_HORIZONTAL;
@@ -57,6 +58,32 @@ class GenericTemplate implements JsonSerializable, WebAccess
     }
 
     /**
+     * @param QuickReplyButton $button
+     * @return $this
+     */
+    public function addQuickReply(QuickReplyButton $button)
+    {
+        $this->quick_replies[] = $button->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param array $buttons
+     * @return $this
+     */
+    public function addQuickReplies(array $buttons)
+    {
+        foreach ($buttons as $button) {
+            if ($button instanceof QuickReplyButton) {
+                $this->quick_replies[] = $button->toArray();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $ratio
      * @return $this
      */
@@ -83,6 +110,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
                     'elements' => $this->elements,
                 ],
             ],
+            'quick_replies' => $this->quick_replies,
         ];
     }
 


### PR DESCRIPTION
generic template add quick reply button

e.g.
```
$bot->reply(GenericTemplate::create()
            ->addImageAspectRatio(GenericTemplate::RATIO_SQUARE)
            ->addElements([
                Element::create('BotMan Documentation')
                    ->subtitle('All about BotMan')
                    ->image('http://botman.io/img/botman-body.png')
                    ->addButton(ElementButton::create('visit')
                        ->url('http://botman.io')
                    )
                    ->addButton(ElementButton::create('tell me more')
                        ->payload('tellmemore')
                        ->type('postback')
                    ),
                Element::create('BotMan Laravel Starter')
                    ->subtitle('This is the best way to start with Laravel and BotMan')
                    ->image('http://botman.io/img/botman-body.png')
                    ->addButton(ElementButton::create('visit')
                        ->url('https://github.com/mpociot/botman-laravel-starter')
                    ),
            ])
            ->addQuickReply(QuickReplyButton::create('title')->payload('POSTBACK_PAYLOAD'))
            ->addQuickReply(QuickReplyButton::create()->type('user_phone_number'))
            ->addQuickReply(QuickReplyButton::create()->type('user_email'))
        );
```