### PR TITLE
botman associated checkbox-plugin message

### DIFF
--- a/src/Events/Standby.php
+++ b/src/Events/Standby.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BotMan\Drivers\Facebook\Events;
+
+class Standby extends FacebookEvent
+{
+    /**
+     * Return the event name to match.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'standby';
+    }
+}

--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -2,8 +2,8 @@
 
 namespace BotMan\Drivers\Facebook\Extensions;
 
-use JsonSerializable;
 use BotMan\BotMan\Interfaces\WebAccess;
+use JsonSerializable;
 
 class GenericTemplate implements JsonSerializable, WebAccess
 {
@@ -18,6 +18,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
 
     /** @var array */
     protected $elements = [];
+    protected $quick_replies = [];
 
     /** @var string */
     protected $imageAspectRatio = self::RATIO_HORIZONTAL;
@@ -57,6 +58,32 @@ class GenericTemplate implements JsonSerializable, WebAccess
     }
 
     /**
+     * @param QuickReplyButton $button
+     * @return $this
+     */
+    public function addQuickReply(QuickReplyButton $button)
+    {
+        $this->quick_replies[] = $button->toArray();
+
+        return $this;
+    }
+
+    /**
+     * @param array $buttons
+     * @return $this
+     */
+    public function addQuickReplies(array $buttons)
+    {
+        foreach ($buttons as $button) {
+            if ($button instanceof QuickReplyButton) {
+                $this->quick_replies[] = $button->toArray();
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * @param string $ratio
      * @return $this
      */
@@ -83,6 +110,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
                     'elements' => $this->elements,
                 ],
             ],
+            'quick_replies' => $this->quick_replies,
         ];
     }
 

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -2,6 +2,7 @@
 
 namespace BotMan\Drivers\Facebook;
 
+use BotMan\Drivers\Facebook\Events\Standby;
 use BotMan\BotMan\Drivers\Events\GenericEvent;
 use BotMan\BotMan\Drivers\HttpDriver;
 use BotMan\BotMan\Interfaces\DriverEventInterface;
@@ -141,6 +142,11 @@ class FacebookDriver extends HttpDriver implements VerifiesService
 
         if (! is_null($event)) {
             $this->driverEvent = $this->getEventFromEventData($event);
+
+            return $this->driverEvent;
+        }else if(!empty($standby = Collection::make($this->event->get('standby'))->first())){//new webhook event standby
+
+            $this->driverEvent = new Standby($standby);
 
             return $this->driverEvent;
         }

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -379,7 +379,8 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         if ($message instanceof Question) {
             $parameters['message'] = $this->convertQuestion($message);
         } elseif (is_object($message) && in_array(get_class($message), $this->templates)) {
-            $parameters['message'] = $message->toArray();
+            unset($parameters['message']['text']);
+            $parameters['message'] = array_merge_recursive($parameters['message'],$message->toArray());
         } elseif ($message instanceof OutgoingMessage) {
             $attachment = $message->getAttachment();
             if (! is_null($attachment) && in_array(get_class($attachment), $this->supportedAttachments)) {

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -133,6 +133,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
                     'timestamp',
                     'message',
                     'postback',
+                    'prior_message',
                 ])->isEmpty() === false;
         })->transform(function ($msg) {
             return Collection::make($msg)->toArray();
@@ -159,6 +160,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
             'timestamp',
             'message',
             'postback',
+            'prior_message',
         ])->keys()->first();
         switch ($name) {
             case 'referral':


### PR DESCRIPTION
botman can't hear prior_message (checkbox-plugin reply).

If the server sends a message with user_ref, the server can associate customer information through "prior_message" after the customer replies

Reference documents:
https://developers.facebook.com/docs/messenger-platform/discovery/checkbox-plugin/#7--handle-the-user-response
