### PR TITLE
Remove profile_pic from default fields when getting a user.

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -460,7 +460,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         $messagingDetails = $this->event->get('messaging')[0];
 
         // field string available at Facebook
-        $fields = 'name,first_name,last_name,profile_pic';
+        $fields = 'name,first_name,last_name';
 
         // WORKPLACE (Facebook for companies)
         // if community isset in sender Object, it is a request done by workplace

--- a/tests/FacebookDriverTest.php
+++ b/tests/FacebookDriverTest.php
@@ -200,10 +200,10 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
     {
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
 
-        $facebookResponse = '{"first_name":"John","last_name":"Doe","profile_pic":"https://facebook.com/profilepic","locale":"en_US","timezone":2,"gender":"male","is_payment_enabled":true}';
+        $facebookResponse = '{"first_name":"John","last_name":"Doe","locale":"en_US","timezone":2,"gender":"male","is_payment_enabled":true}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name,profile_pic&access_token=Foo')->andReturn(new Response($facebookResponse));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name&access_token=Foo')->andReturn(new Response($facebookResponse));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $message = $driver->getMessages()[0];
@@ -213,7 +213,6 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('John', $user->getFirstName());
         $this->assertEquals('Doe', $user->getLastName());
         $this->assertNull($user->getUsername());
-        $this->assertEquals('https://facebook.com/profilepic', $user->getProfilePic());
         $this->assertEquals('en_US', $user->getLocale());
         $this->assertEquals('2', $user->getTimezone());
         $this->assertEquals('male', $user->getGender());
@@ -243,7 +242,7 @@ class FacebookDriverTest extends PHPUnit_Framework_TestCase
         $request = '{"object":"page","entry":[{"id":"111899832631525","time":1480279487271,"messaging":[{"sender":{"id":"1433960459967306"},"recipient":{"id":"111899832631525"},"timestamp":1480279487147,"message":{"mid":"mid.1480279487147:4388d3b344","seq":36,"text":"Hi Julia"}}]}]}';
 
         $htmlInterface = m::mock(Curl::class);
-        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name,profile_pic&access_token=Foo')->andReturn(new Response('{}'));
+        $htmlInterface->shouldReceive('get')->once()->with('https://graph.facebook.com/v3.0/1433960459967306?fields=name,first_name,last_name&access_token=Foo')->andReturn(new Response('{}'));
 
         $driver = $this->getDriver($request, null, '', $htmlInterface);
         $driver->getMessages()[0];


### PR DESCRIPTION
Facebook has updated their User Profile API in regards to GDPR. This looks like it should only involve Europe but people have been reporting that they are affected even outside of Europe.

This is the error message you will get: `(#10) This action was not submitted due to new privacy rules in Europe. See developer documentation for more info`

You can have a look at the [Changelog](https://developers.facebook.com/docs/messenger-platform/europe-updates/) where it says under **December 16, 2020** that 
```
User Profile API will be supported for all fields except for profile_pic. API calls with profile_pic field will return an error message.
```

The PR removes the `profile_pic` from default as a quick fix. Might have to take a look at doing some changes at `getProfilePic` methods and so on. 