### PR TITLE
fixes #122

### DIFF
--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -117,7 +117,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     public function verifyRequest(Request $request)
     {
         if ($request->get('hub_mode') === 'subscribe' && $request->get('hub_verify_token') === $this->config->get('verification')) {
-            return Response::create($request->get('hub_challenge'))->send();
+            return (new Response($request->get('hub_challenge')))->send();
         }
     }
 


### PR DESCRIPTION
Response::create method was deprecated on symfony/http-foundation v6