### PR TITLE
Updates signature for JsonSerializable, update to use the latest Facebook Api version, and small type errors

### DIFF
--- a/src/Extensions/ButtonTemplate.php
+++ b/src/Extensions/ButtonTemplate.php
@@ -73,7 +73,7 @@ class ButtonTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/Element.php
+++ b/src/Extensions/Element.php
@@ -143,7 +143,7 @@ class Element implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ElementButton.php
+++ b/src/Extensions/ElementButton.php
@@ -211,7 +211,7 @@ class ElementButton
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/GenericTemplate.php
+++ b/src/Extensions/GenericTemplate.php
@@ -117,7 +117,7 @@ class GenericTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ListTemplate.php
+++ b/src/Extensions/ListTemplate.php
@@ -94,7 +94,7 @@ class ListTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/MediaAttachmentElement.php
+++ b/src/Extensions/MediaAttachmentElement.php
@@ -84,7 +84,7 @@ class MediaAttachmentElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/MediaTemplate.php
+++ b/src/Extensions/MediaTemplate.php
@@ -51,7 +51,7 @@ class MediaTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/MediaUrlElement.php
+++ b/src/Extensions/MediaUrlElement.php
@@ -84,7 +84,7 @@ class MediaUrlElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/QuickReplyButton.php
+++ b/src/Extensions/QuickReplyButton.php
@@ -98,7 +98,7 @@ class QuickReplyButton implements QuestionActionInterface
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptAddress.php
+++ b/src/Extensions/ReceiptAddress.php
@@ -116,7 +116,7 @@ class ReceiptAddress implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptAdjustment.php
+++ b/src/Extensions/ReceiptAdjustment.php
@@ -56,7 +56,7 @@ class ReceiptAdjustment implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptElement.php
+++ b/src/Extensions/ReceiptElement.php
@@ -114,7 +114,7 @@ class ReceiptElement implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptSummary.php
+++ b/src/Extensions/ReceiptSummary.php
@@ -86,7 +86,7 @@ class ReceiptSummary implements JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/Extensions/ReceiptTemplate.php
+++ b/src/Extensions/ReceiptTemplate.php
@@ -228,7 +228,7 @@ class ReceiptTemplate implements JsonSerializable, WebAccess
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }

--- a/src/FacebookDriver.php
+++ b/src/FacebookDriver.php
@@ -76,7 +76,7 @@ class FacebookDriver extends HttpDriver implements VerifiesService
     /** @var DriverEventInterface */
     protected $driverEvent;
 
-    protected $facebookProfileEndpoint = 'https://graph.facebook.com/v3.0/';
+    protected $facebookProfileEndpoint = 'https://graph.facebook.com/v22.0/';
 
     /** @var bool If the incoming request is a FB postback */
     protected $isPostback = false;
@@ -381,12 +381,18 @@ class FacebookDriver extends HttpDriver implements VerifiesService
         if ($message instanceof Question) {
             $parameters['message'] = $this->convertQuestion($message);
         } elseif (is_object($message) && in_array(get_class($message), $this->templates)) {
+            /**
+             * @var mixed $message
+             */
             $parameters['message'] = $message->toArray();
         } elseif ($message instanceof OutgoingMessage) {
             $attachment = $message->getAttachment();
             if (! is_null($attachment) && in_array(get_class($attachment), $this->supportedAttachments)) {
                 $attachmentType = strtolower(basename(str_replace('\\', '/', get_class($attachment))));
                 unset($parameters['message']['text']);
+                /**
+                 * @var Video|Audio|Image|File $attachment
+                 */
                 $parameters['message']['attachment'] = [
                     'type' => $attachmentType,
                     'payload' => [


### PR DESCRIPTION
This PR updates the signature of JsonSerializable classes in templates, also updates to use the latest Facebook Api version, and adds some small `@var` to silence the linter.